### PR TITLE
Fix child update flow

### DIFF
--- a/src/java/control/NinoBean.java
+++ b/src/java/control/NinoBean.java
@@ -218,24 +218,28 @@ public class NinoBean implements Serializable {
     return "listarNinos?faces-redirect=true";
 }
     public void cargarNinoPorId() {
-    try {
-        if (nino != null && nino.getIdNino() > 0) {
-            Nino cargado = ninoDAO.buscarNinoPorId(nino.getIdNino());
-            if (cargado != null) {
-                this.nino = cargado; // reemplazamos el niño con los datos de BD
-            } else {
-                FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage(FacesMessage.SEVERITY_WARN,
-                    "No se encontró el niño con ID: " + nino.getIdNino(), null));
+        try {
+            if (FacesContext.getCurrentInstance().isPostback()) {
+                return; // evitar sobreescribir los datos enviados por el usuario en POST
             }
+
+            if (nino != null && nino.getIdNino() > 0) {
+                Nino cargado = ninoDAO.buscarNinoPorId(nino.getIdNino());
+                if (cargado != null) {
+                    this.nino = cargado; // reemplazamos el niño con los datos de BD
+                } else {
+                    FacesContext.getCurrentInstance().addMessage(null,
+                        new FacesMessage(FacesMessage.SEVERITY_WARN,
+                        "No se encontró el niño con ID: " + nino.getIdNino(), null));
+                }
+            }
+        } catch (Exception e) {
+            FacesContext.getCurrentInstance().addMessage(null,
+                new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                "Error al cargar el niño: " + e.getMessage(), null));
+            e.printStackTrace();
         }
-    } catch (Exception e) {
-        FacesContext.getCurrentInstance().addMessage(null,
-            new FacesMessage(FacesMessage.SEVERITY_ERROR,
-            "Error al cargar el niño: " + e.getMessage(), null));
-        e.printStackTrace();
     }
-}
 
 
   public String actualizarNino() {

--- a/web/editarNino.xhtml
+++ b/web/editarNino.xhtml
@@ -14,6 +14,7 @@
     </f:metadata>
 
     <h:form enctype="multipart/form-data">
+        <h:inputHidden id="idNinoHidden" value="#{ninoBean.nino.idNino}" />
         <h2>Editar Información del Niño</h2>
 
         <h:panelGrid columns="4" columnClasses="label,value,label,value" cellpadding="5">


### PR DESCRIPTION
## Summary
- avoid reloading the niño record during postbacks so the edit form keeps the values entered by the user
- send the niño identifier as a hidden field to keep it available when saving changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cebd44d7a08332b60e51c72b182081