### PR TITLE
Stabilize niño update handling and restore edit navigation

### DIFF
--- a/src/java/dao/NinoDAO.java
+++ b/src/java/dao/NinoDAO.java
@@ -111,7 +111,9 @@ public class NinoDAO {
 
     // Actualizar niño completo
     public boolean actualizarNino(Nino n) {
-        String sql = "UPDATE ninos SET nombres=?, apellidos=?, fecha_nacimiento=?, genero=?, nacionalidad=?, foto=? WHERE id_nino=?";
+        String sql = "UPDATE ninos SET nombres=?, apellidos=?, fecha_nacimiento=?, documento=?, genero=?, " +
+                     "nacionalidad=?, fecha_ingreso=?, hogar_id=?, padre_id=?, foto=?, carnet_vacunacion=?, certificado_eps=? " +
+                     "WHERE id_nino=?";
 
         try (Connection con = ConDB.getConnection();
              PreparedStatement ps = con.prepareStatement(sql)) {
@@ -125,10 +127,43 @@ public class NinoDAO {
                 ps.setNull(3, Types.DATE);
             }
 
-            ps.setString(4, n.getGenero());
-            ps.setString(5, n.getNacionalidad());
-            ps.setString(6, n.getFoto()); // si no se sube nueva foto, queda la existente
-            ps.setInt(7, n.getIdNino());
+            if (n.getDocumento() != null) {
+                ps.setLong(4, n.getDocumento());
+            } else {
+                ps.setNull(4, Types.BIGINT);
+            }
+
+            ps.setString(5, n.getGenero());
+            ps.setString(6, n.getNacionalidad());
+
+            if (n.getFechaIngreso() != null) {
+                ps.setDate(7, new java.sql.Date(n.getFechaIngreso().getTime()));
+            } else {
+                ps.setNull(7, Types.DATE);
+            }
+
+            ps.setInt(8, n.getHogarId());
+            ps.setInt(9, n.getPadreId());
+
+            if (n.getFoto() != null) {
+                ps.setString(10, n.getFoto());
+            } else {
+                ps.setNull(10, Types.VARCHAR);
+            }
+
+            if (n.getCarnetVacunacion() != null) {
+                ps.setString(11, n.getCarnetVacunacion());
+            } else {
+                ps.setNull(11, Types.VARCHAR);
+            }
+
+            if (n.getCertificadoEps() != null) {
+                ps.setString(12, n.getCertificadoEps());
+            } else {
+                ps.setNull(12, Types.VARCHAR);
+            }
+
+            ps.setInt(13, n.getIdNino());
 
             return ps.executeUpdate() > 0;
 

--- a/web/editarNino.xhtml
+++ b/web/editarNino.xhtml
@@ -14,6 +14,7 @@
     </f:metadata>
 
     <h:form enctype="multipart/form-data">
+        <h:inputHidden id="idNinoHidden" value="#{ninoBean.nino.idNino}" />
         <h2>Editar Información del Niño</h2>
 
         <h:panelGrid columns="4" columnClasses="label,value,label,value" cellpadding="5">

--- a/web/listarNinos.xhtml
+++ b/web/listarNinos.xhtml
@@ -64,10 +64,8 @@
             <p:column headerText="Acciones" style="width:120px; text-align:center;">
                 <!-- Editar -->
                 <p:commandButton icon="pi pi-pencil" title="Editar"
-                                 action="editarNino.xhtml"
-                                 ajax="false">
-                    <f:param name="idNino" value="#{n.idNino}" />
-                </p:commandButton>
+                                 action="#{ninoBean.irEditar(n.idNino)}"
+                                 ajax="false" />
 
                 <!-- Eliminar -->
                 <p:commandButton icon="pi pi-trash" title="Eliminar"


### PR DESCRIPTION
## Summary
- link matriculated children to the padre record id instead of the usuario id when persisting new rows
- tighten the update routine to trim required fields, preserve original values when the form leaves them blank, and keep the success message after redirecting
- expose a bean method for edit navigation and switch the list view button to use an action compatible with PrimeFaces 8

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cebd44d7a08332b60e51c72b182081