### PR TITLE
Fix padre reference for enrollment

### DIFF
--- a/src/java/control/NinoBean.java
+++ b/src/java/control/NinoBean.java
@@ -121,7 +121,7 @@ public class NinoBean implements Serializable {
             // =============================
             // 5. Crear NIÑO
             // =============================
-            nino.setPadreId(usuarioId); // FK al usuario del padre
+            nino.setPadreId(idPadre); // FK al registro del padre en tabla padres
             int idNino = ninoDAO.insert(nino);
 
             String rutaFoto = guardarArchivo(fotoNinoPart, "ninos/" + idNino);

--- a/src/java/modelo/Nino.java
+++ b/src/java/modelo/Nino.java
@@ -23,7 +23,7 @@ public class Nino implements Serializable {
     private String nacionalidad;         // puede ser null
     private Date fechaIngreso;           // DEFAULT CURRENT_DATE
     private int hogarId;                 // NOT NULL FK -> hogares_comunitarios.id_hogar
-    private int padreId;                 // NOT NULL FK -> usuarios.id_usuario
+    private int padreId;                 // NOT NULL FK -> padres.id_padre
 
     // Campos para archivos (rutas en servidor)
     private String foto;                 // ruta foto del niño


### PR DESCRIPTION
## Summary
- ensure `guardarMatricula` persiste el identificador real del padre para que las búsquedas posteriores encuentren sus correos
- documenta en el modelo `Nino` que `padreId` referencia a `padres.id_padre`

## Testing
- no se ejecutaron pruebas (no disponibles)


------
https://chatgpt.com/codex/tasks/task_b_68d0c28677948332b735dcf1920dce5c