### PR TITLE
Corregir selección y validaciones en envío de correos masivos

### DIFF
--- a/web/correos.xhtml
+++ b/web/correos.xhtml
@@ -17,9 +17,9 @@
         <p:messages id="msgs" closable="true"/>
 
         <p:panel header="Lista de Padres">
-            <p:dataTable var="padre" value="#{correoBean.padres}" 
-                         selection="#{correoBean.correosDestino}" 
-                         selectionMode="multiple" rowKey="#{padre.correo}" 
+            <p:dataTable var="padre" value="#{correoBean.padres}"
+                         selection="#{correoBean.padresSeleccionados}"
+                         selectionMode="multiple" rowKey="#{padre.correo}"
                          paginator="true" rows="10">
 
                 <!-- Checkbox para seleccionar individual y seleccionar todo -->


### PR DESCRIPTION
## Summary
- Ajusté el bean de correos para manejar la selección como una lista de usuarios y evitar conversiones inválidas al construir los destinatarios.
- Validé asunto, mensaje y direcciones antes de enviar, normalizando los valores y limpiando la selección tras un envío exitoso.
- Inicialicé las colecciones utilizadas en la vista para prevenir estados nulos cuando la madre no tiene un hogar asociado.

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d0c55662388332a52c29781f6f8d6d