### PR TITLE
Corrige acción del botón cancelar en crear niño

### DIFF
--- a/web/crearNino.xhtml
+++ b/web/crearNino.xhtml
@@ -120,7 +120,7 @@
 
 
     <p:commandButton value="Cancelar" immediate="true"
-                     action="#{NinoBean.cancelar}"
+                     action="#{ninoBean.cancelar}"
                      styleClass="ui-button-secondary"/>
    
 </h:form>


### PR DESCRIPTION
## Summary
- corrige la acción del botón Cancelar en la vista de creación de niño para usar el managed bean correcto

## Testing
- no se ejecutaron pruebas (no aplicaba)


------
https://chatgpt.com/codex/tasks/task_b_68d16fdfc49c83329c92ab4c924a996d