### PR TITLE
Mejorar vista de creación de niño

### DIFF
--- a/web/crearNino.xhtml
+++ b/web/crearNino.xhtml
@@ -4,126 +4,458 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
 <h:head>
-    <title>Matrícula de Niño</title>
+    <title>Registrar Matrícula de Niño</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"/>
+
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Roboto', sans-serif;
+            background-image: url("#{resource['img/fondoAdmin.png']}");
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            background-attachment: fixed;
+        }
+
+        header {
+            background-color: rgba(255, 255, 255, 0.85);
+            padding: 15px 30px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            border-bottom: 2px solid #e5d5f5;
+            backdrop-filter: blur(4px);
+            flex-wrap: wrap;
+        }
+
+        header img {
+            height: 60px;
+        }
+
+        nav {
+            flex-grow: 1;
+            margin-left: 40px;
+        }
+
+        nav ul {
+            list-style: none;
+            display: flex;
+            gap: 20px;
+            padding: 0;
+            margin: 0;
+            flex-wrap: wrap;
+        }
+
+        nav ul li a,
+        nav ul li h\:link {
+            text-decoration: none;
+            font-weight: bold;
+            color: #007BFF;
+            transition: color 0.3s ease;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        nav ul li a:hover,
+        nav ul li h\:link:hover {
+            color: #0056b3;
+        }
+
+        .btn-cerrar {
+            color: #007BFF;
+            text-decoration: none;
+            font-weight: bold;
+            font-size: 16px;
+            padding: 8px 12px;
+            border: none;
+            background: none;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+
+        .btn-cerrar:hover {
+            background-color: #0056b3;
+            color: white;
+        }
+
+        .main-title {
+            text-align: center;
+            padding: 20px;
+            font-size: 29px;
+            font-weight: bold;
+            color: #004080;
+            background-color: rgba(204, 228, 231, 0.85);
+            width: 80%;
+            margin: 30px auto 10px;
+            border-radius: 10px;
+        }
+
+        .global-messages {
+            max-width: 1100px;
+            margin: 10px auto 20px;
+        }
+
+        .global-messages .ui-messages-info,
+        .global-messages .ui-messages-warn,
+        .global-messages .ui-messages-error {
+            border-radius: 8px;
+            border-left: 5px solid #007BFF;
+        }
+
+        .global-messages .ui-messages-error {
+            border-left-color: #dc3545;
+        }
+
+        .global-messages .ui-messages-warn {
+            border-left-color: #ffc107;
+        }
+
+        .form-wrapper {
+            display: flex;
+            justify-content: space-between;
+            gap: 30px;
+            max-width: 1100px;
+            margin: 0 auto 25px;
+            flex-wrap: wrap;
+        }
+
+        .form-card {
+            background-color: rgba(255, 255, 255, 0.95);
+            flex: 1;
+            min-width: 300px;
+            padding: 25px;
+            border-radius: 12px;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.05);
+            border-left: 6px solid #007BFF;
+        }
+
+        .form-card h3 {
+            font-size: 20px;
+            color: #004080;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+
+        .form-field {
+            margin-bottom: 18px;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .field-label {
+            font-weight: bold;
+            margin-bottom: 6px;
+            color: #003366;
+        }
+
+        .input-field,
+        .form-card select,
+        .form-card textarea,
+        .form-card input[type="file"] {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 15px;
+        }
+
+        .form-card textarea {
+            min-height: 90px;
+            resize: vertical;
+        }
+
+        .helper-text {
+            font-size: 13px;
+            color: #5a5a5a;
+            margin-top: 4px;
+        }
+
+        .error-msg {
+            color: #d93025;
+            font-size: 13px;
+            margin-top: 4px;
+        }
+
+        .button-group {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin: 40px auto 60px;
+            flex-wrap: wrap;
+        }
+
+        .btn-guardar,
+        .btn-volver,
+        .btn-lista {
+            background-color: #007BFF !important;
+            color: white !important;
+            font-weight: bold;
+            padding: 12px 30px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+            font-size: 16px;
+            text-decoration: none;
+            min-width: 200px;
+            text-align: center;
+        }
+
+        .btn-volver {
+            background-color: #6c757d !important;
+        }
+
+        .btn-lista {
+            background-color: #17a2b8 !important;
+        }
+
+        .btn-guardar:hover,
+        .btn-volver:hover,
+        .btn-lista:hover {
+            filter: brightness(0.9);
+        }
+
+        @media screen and (max-width: 800px) {
+            .form-wrapper {
+                flex-direction: column;
+                align-items: center;
+            }
+
+            .btn-guardar,
+            .btn-volver,
+            .btn-lista {
+                min-width: 100%;
+            }
+        }
+    </style>
 </h:head>
+
 <h:body>
 
-<h:form enctype="multipart/form-data">
-    <h:messages globalOnly="true" style="color:red;" />
+    <header>
+        <h:graphicImage library="img" name="logoSinFondo.png" alt="Logo ICBF" />
+        <nav>
+            <ul>
+                <li>
+                    <h:link outcome="madreDashboard">
+                        <i class="fas fa-home"></i>
+                        Inicio Madre
+                    </h:link>
+                </li>
+                <li>
+                    <h:link outcome="listarNinos">
+                        <i class="fas fa-list"></i>
+                        Lista de Niños
+                    </h:link>
+                </li>
+            </ul>
+        </nav>
+        <h:form>
+            <h:commandLink action="#{loginBean.logout}" styleClass="btn-cerrar">
+                <i class="fas fa-sign-out-alt"></i> Cerrar sesión
+            </h:commandLink>
+        </h:form>
+    </header>
 
-    <!-- ====================== -->
-    <!-- DATOS DEL NIÑO -->
-    <!-- ====================== -->
-    <h2>Datos del Niño</h2>
-    <h:panelGrid columns="2" columnClasses="label,value">
+    <div class="main-title">ICBF - CONECTA | Registrar Matrícula de Niño</div>
 
-        <h:outputLabel for="nombresN" value="Nombres:" />
-        <h:inputText id="nombresN" value="#{ninoBean.nino.nombres}" required="true" />
+    <h:form id="formCrearNino" enctype="multipart/form-data">
+        <p:messages id="globalMessages" showDetail="true" showSummary="false" closable="true" styleClass="global-messages"/>
 
-        <h:outputLabel for="apellidosN" value="Apellidos:" />
-        <h:inputText id="apellidosN" value="#{ninoBean.nino.apellidos}" required="true" />
+        <div class="form-wrapper">
+            <div class="form-card">
+                <h3>Datos del Niño</h3>
 
-        <h:outputLabel for="documentoN" value="Documento:" />
-        <h:inputText id="documentoN" value="#{ninoBean.nino.documento}" />
+                <div class="form-field">
+                    <h:outputLabel for="nombresN" value="Nombres" styleClass="field-label"/>
+                    <h:inputText id="nombresN" value="#{ninoBean.nino.nombres}" required="true"
+                                 requiredMessage="Por favor ingresa los nombres del niño." styleClass="input-field"/>
+                    <h:message for="nombresN" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="fechaNac" value="Fecha de nacimiento:" />
-        <p:calendar id="fechaNac"
-                    value="#{ninoBean.nino.fechaNacimiento}"
-                    pattern="yyyy-MM-dd"
-                    showOn="button"
-                    required="true" />
+                <div class="form-field">
+                    <h:outputLabel for="apellidosN" value="Apellidos" styleClass="field-label"/>
+                    <h:inputText id="apellidosN" value="#{ninoBean.nino.apellidos}" required="true"
+                                 requiredMessage="Por favor ingresa los apellidos del niño." styleClass="input-field"/>
+                    <h:message for="apellidosN" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="genero" value="Género:" />
-        <h:selectOneMenu id="genero" value="#{ninoBean.nino.genero}">
-            <f:selectItem itemLabel="Seleccione..." itemValue="" />
-            <f:selectItem itemLabel="Masculino" itemValue="masculino" />
-            <f:selectItem itemLabel="Femenino" itemValue="femenino" />
-            <f:selectItem itemLabel="Otro" itemValue="otro" />
-            <f:selectItem itemLabel="No especificado" itemValue="no_especificado" />
-        </h:selectOneMenu>
+                <div class="form-field">
+                    <h:outputLabel for="documentoN" value="Documento" styleClass="field-label"/>
+                    <h:inputText id="documentoN" value="#{ninoBean.nino.documento}" styleClass="input-field"/>
+                    <span class="helper-text">Opcional.</span>
+                </div>
 
-        <h:outputLabel for="nacionalidad" value="Nacionalidad:" />
-        <h:inputText id="nacionalidad" value="#{ninoBean.nino.nacionalidad}" />
+                <div class="form-field">
+                    <h:outputLabel for="fechaNac" value="Fecha de nacimiento" styleClass="field-label"/>
+                    <p:calendar id="fechaNac"
+                                value="#{ninoBean.nino.fechaNacimiento}"
+                                pattern="yyyy-MM-dd"
+                                showIcon="true"
+                                navigator="true"
+                                yearRange="1950:2100"
+                                required="true"
+                                requiredMessage="Selecciona la fecha de nacimiento."
+                                inputStyleClass="input-field"/>
+                    <h:message for="fechaNac" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="hogar" value="Hogar comunitario:" />
-        <h:selectOneMenu id="hogar" value="#{ninoBean.nino.hogarId}" required="true">
-            <f:selectItem itemLabel="Seleccione un hogar..." itemValue="" noSelectionOption="true"/>
-            <f:selectItems value="#{ninoBean.listaHogares}" var="h"
-                           itemValue="#{h.idHogar}"
-                           itemLabel="#{h.nombreHogar} - #{h.localidad}" />
-        </h:selectOneMenu>
+                <div class="form-field">
+                    <h:outputLabel for="genero" value="Género" styleClass="field-label"/>
+                    <h:selectOneMenu id="genero" value="#{ninoBean.nino.genero}" styleClass="input-field">
+                        <f:selectItem itemLabel="Seleccione..." itemValue=""/>
+                        <f:selectItem itemLabel="Masculino" itemValue="masculino"/>
+                        <f:selectItem itemLabel="Femenino" itemValue="femenino"/>
+                        <f:selectItem itemLabel="Otro" itemValue="otro"/>
+                        <f:selectItem itemLabel="No especificado" itemValue="no_especificado"/>
+                    </h:selectOneMenu>
+                </div>
 
-        <h:outputLabel for="fotoNino" value="Foto del niño:" />
-        <h:inputFile id="fotoNino" value="#{ninoBean.fotoNinoPart}" required="true" />
+                <div class="form-field">
+                    <h:outputLabel for="nacionalidad" value="Nacionalidad" styleClass="field-label"/>
+                    <h:inputText id="nacionalidad" value="#{ninoBean.nino.nacionalidad}" styleClass="input-field"/>
+                </div>
 
-    </h:panelGrid>
+                <div class="form-field">
+                    <h:outputLabel for="hogar" value="Hogar comunitario" styleClass="field-label"/>
+                    <h:selectOneMenu id="hogar" value="#{ninoBean.nino.hogarId}" required="true" styleClass="input-field"
+                                    requiredMessage="Selecciona un hogar comunitario.">
+                        <f:selectItem itemLabel="Seleccione un hogar..." itemValue="" noSelectionOption="true"/>
+                        <f:selectItems value="#{ninoBean.listaHogares}" var="h"
+                                       itemValue="#{h.idHogar}"
+                                       itemLabel="#{h.nombreHogar} - #{h.localidad}"/>
+                    </h:selectOneMenu>
+                    <h:message for="hogar" styleClass="error-msg"/>
+                </div>
 
-    <p:separator/>
+                <div class="form-field">
+                    <h:outputLabel for="fotoNino" value="Foto del niño" styleClass="field-label"/>
+                    <h:inputFile id="fotoNino" value="#{ninoBean.fotoNinoPart}" required="true"
+                                 requiredMessage="Debes adjuntar la foto del niño." styleClass="input-field"/>
+                    <h:message for="fotoNino" styleClass="error-msg"/>
+                </div>
+            </div>
 
-    <!-- ====================== -->
-    <!-- DATOS DEL PADRE -->
-    <!-- ====================== -->
-    <h2>Datos del Padre</h2>
-    <h:panelGrid columns="2" columnClasses="label,value">
+            <div class="form-card">
+                <h3>Datos del Padre</h3>
 
-        <h:outputLabel for="nombresP" value="Nombres:" />
-        <h:inputText id="nombresP" value="#{ninoBean.usuarioPadre.nombres}" required="true" />
+                <div class="form-field">
+                    <h:outputLabel for="nombresP" value="Nombres" styleClass="field-label"/>
+                    <h:inputText id="nombresP" value="#{ninoBean.usuarioPadre.nombres}" required="true"
+                                 requiredMessage="Ingresa los nombres del padre." styleClass="input-field"/>
+                    <h:message for="nombresP" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="apellidosP" value="Apellidos:" />
-        <h:inputText id="apellidosP" value="#{ninoBean.usuarioPadre.apellidos}" required="true" />
+                <div class="form-field">
+                    <h:outputLabel for="apellidosP" value="Apellidos" styleClass="field-label"/>
+                    <h:inputText id="apellidosP" value="#{ninoBean.usuarioPadre.apellidos}" required="true"
+                                 requiredMessage="Ingresa los apellidos del padre." styleClass="input-field"/>
+                    <h:message for="apellidosP" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="documentoP" value="Documento:" />
-        <h:inputText id="documentoP" value="#{ninoBean.usuarioPadre.documento}" required="true" />
+                <div class="form-field">
+                    <h:outputLabel for="documentoP" value="Documento" styleClass="field-label"/>
+                    <h:inputText id="documentoP" value="#{ninoBean.usuarioPadre.documento}" required="true"
+                                 requiredMessage="Ingresa el documento del padre." styleClass="input-field"/>
+                    <h:message for="documentoP" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="ocupacion" value="Ocupación:" />
-        <h:inputText id="ocupacion" value="#{ninoBean.padre.ocupacion}" />
+                <div class="form-field">
+                    <h:outputLabel for="correoP" value="Correo electrónico" styleClass="field-label"/>
+                    <h:inputText id="correoP" value="#{ninoBean.usuarioPadre.correo}" required="true"
+                                 requiredMessage="Ingresa el correo electrónico." styleClass="input-field"/>
+                    <h:message for="correoP" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="estrato" value="Estrato:" />
-        <h:inputText id="estrato" value="#{ninoBean.padre.estrato}" />
+                <div class="form-field">
+                    <h:outputLabel for="direccionP" value="Dirección" styleClass="field-label"/>
+                    <h:inputText id="direccionP" value="#{ninoBean.usuarioPadre.direccion}" styleClass="input-field"/>
+                </div>
 
-        <h:outputLabel for="telEmerg" value="Teléfono de emergencia:" />
-        <h:inputText id="telEmerg" value="#{ninoBean.padre.telefonoContactoEmergencia}" />
+                <div class="form-field">
+                    <h:outputLabel for="telefonoP" value="Teléfono" styleClass="field-label"/>
+                    <h:inputText id="telefonoP" value="#{ninoBean.usuarioPadre.telefono}" styleClass="input-field"/>
+                </div>
 
-        <h:outputLabel for="nomEmerg" value="Nombre contacto de emergencia:" />
-        <h:inputText id="nomEmerg" value="#{ninoBean.padre.nombreContactoEmergencia}" />
+                <div class="form-field">
+                    <h:outputLabel for="pass1" value="Contraseña" styleClass="field-label"/>
+                    <h:inputSecret id="pass1" value="#{ninoBean.password1}" required="true" redisplay="true"
+                                   requiredMessage="Ingresa una contraseña." styleClass="input-field"/>
+                    <h:message for="pass1" styleClass="error-msg"/>
+                </div>
 
-        <h:outputLabel for="sitEcon" value="Situación económica hogar:" />
-        <h:inputTextarea id="sitEcon" value="#{ninoBean.padre.situacionEconomicaHogar}" rows="3" cols="30" />
+                <div class="form-field">
+                    <h:outputLabel for="pass2" value="Confirmar contraseña" styleClass="field-label"/>
+                    <h:inputSecret id="pass2" value="#{ninoBean.password2}" required="true" redisplay="true"
+                                   requiredMessage="Confirma la contraseña." styleClass="input-field"/>
+                    <h:message for="pass2" styleClass="error-msg"/>
+                </div>
+            </div>
 
-        <h:outputLabel for="docPadre" value="Documento de identidad (archivo):" />
-        <h:inputFile id="docPadre" value="#{ninoBean.docPadrePart}" required="true" />
+            <div class="form-card">
+                <h3>Contacto y Documentos</h3>
 
-        <h:outputLabel for="correoP" value="Correo electrónico:" />
-        <h:inputText id="correoP" value="#{ninoBean.usuarioPadre.correo}" required="true" />
+                <div class="form-field">
+                    <h:outputLabel for="ocupacion" value="Ocupación" styleClass="field-label"/>
+                    <h:inputText id="ocupacion" value="#{ninoBean.padre.ocupacion}" styleClass="input-field"/>
+                </div>
 
-        <h:outputLabel for="direccionP" value="Dirección:" />
-        <h:inputText id="direccionP" value="#{ninoBean.usuarioPadre.direccion}" />
+                <div class="form-field">
+                    <h:outputLabel for="estrato" value="Estrato" styleClass="field-label"/>
+                    <h:inputText id="estrato" value="#{ninoBean.padre.estrato}" styleClass="input-field"/>
+                </div>
 
-        <h:outputLabel for="telefonoP" value="Teléfono:" />
-        <h:inputText id="telefonoP" value="#{ninoBean.usuarioPadre.telefono}" />
+                <div class="form-field">
+                    <h:outputLabel for="telEmerg" value="Teléfono de emergencia" styleClass="field-label"/>
+                    <h:inputText id="telEmerg" value="#{ninoBean.padre.telefonoContactoEmergencia}" styleClass="input-field"/>
+                </div>
 
-        <h:outputLabel for="pass1" value="Contraseña:" />
-        <h:inputSecret id="pass1" value="#{ninoBean.password1}" required="true" redisplay="true"/>
+                <div class="form-field">
+                    <h:outputLabel for="nomEmerg" value="Nombre contacto de emergencia" styleClass="field-label"/>
+                    <h:inputText id="nomEmerg" value="#{ninoBean.padre.nombreContactoEmergencia}" styleClass="input-field"/>
+                </div>
 
-        <h:outputLabel for="pass2" value="Confirmar contraseña:" />
-        <h:inputSecret id="pass2" value="#{ninoBean.password2}" required="true" redisplay="true"/>
+                <div class="form-field">
+                    <h:outputLabel for="sitEcon" value="Situación económica del hogar" styleClass="field-label"/>
+                    <h:inputTextarea id="sitEcon" value="#{ninoBean.padre.situacionEconomicaHogar}" rows="4"
+                                     styleClass="input-field"/>
+                </div>
 
-    </h:panelGrid>
+                <div class="form-field">
+                    <h:outputLabel for="docPadre" value="Documento de identidad (archivo)" styleClass="field-label"/>
+                    <h:inputFile id="docPadre" value="#{ninoBean.docPadrePart}" required="true"
+                                 requiredMessage="Adjunta el documento del padre." styleClass="input-field"/>
+                    <h:message for="docPadre" styleClass="error-msg"/>
+                </div>
+            </div>
+        </div>
 
-    <p:separator/>
+        <div class="button-group">
+            <p:commandButton value="Guardar Matrícula"
+                             action="#{ninoBean.guardarMatricula}"
+                             ajax="false"
+                             styleClass="btn-guardar"/>
 
-    <!-- BOTONES -->
-<p:commandButton value="Guardar Matrícula"
-                 action="#{ninoBean.guardarMatricula}"
-                 ajax="false"
-                 styleClass="ui-button-success"/>
+            <p:commandButton value="Cancelar"
+                             action="#{ninoBean.cancelar}"
+                             immediate="true"
+                             ajax="false"
+                             styleClass="btn-volver"/>
 
-
-    <p:commandButton value="Cancelar" immediate="true"
-                     action="#{ninoBean.cancelar}"
-                     styleClass="ui-button-secondary"/>
-   
-</h:form>
+            <p:button value="Ver Lista de Niños"
+                      outcome="listarNinos"
+                      styleClass="btn-lista"/>
+        </div>
+    </h:form>
 
 </h:body>
 </html>


### PR DESCRIPTION
## Summary
- Rediseñé la página de matrícula de niños siguiendo la línea visual de las demás vistas estilizadas.
- Organicé los campos en tarjetas con mensajes de validación y cabecera consistente con navegación.
- Añadí un botón de acceso directo al listado de niños y habilité la selección de año en el calendario de nacimiento.

## Testing
- No tests were run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68d172e1da1083328e83c15d8f7f50a9