### PR TITLE
Separar registro de padre y matrícula de niño

### DIFF
--- a/src/java/control/NinoBean.java
+++ b/src/java/control/NinoBean.java
@@ -4,15 +4,16 @@ import dao.HogarComunitarioDAO;
 import dao.NinoDAO;
 import dao.PadreDAO;
 import dao.UsuarioDAO;
+import modelo.HogarComunitario;
 import modelo.Nino;
 import modelo.Padre;
 import modelo.Usuario;
-import modelo.HogarComunitario;
 
 import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
+import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.servlet.http.Part;
 import java.io.InputStream;
@@ -20,12 +21,8 @@ import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.MessageDigest;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Types;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @ManagedBean(name = "ninoBean")
@@ -33,23 +30,19 @@ import java.util.UUID;
 public class NinoBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final String BASE_DIR = "C:/icbf_uploads";
 
     private Nino nino;
-    private Padre padre;
-    private Usuario usuarioPadre;
-
-    private String password1;
-    private String password2;
-
     private Part fotoNinoPart;
-    private Part docPadrePart;
 
-    private NinoDAO ninoDAO;
-    private PadreDAO padreDAO;
-    private UsuarioDAO usuarioDAO;
-    private HogarComunitarioDAO hogarDAO;
+    private Integer padreIdSeleccionado;
+    private Padre padreSeleccionado;
+    private Usuario usuarioPadreSeleccionado;
 
-    private static final String BASE_DIR = "C:/icbf_uploads";
+    private transient NinoDAO ninoDAO;
+    private transient PadreDAO padreDAO;
+    private transient UsuarioDAO usuarioDAO;
+    private transient HogarComunitarioDAO hogarDAO;
 
     private List<Nino> listaNinos;
     private List<HogarComunitario> listaHogares;
@@ -57,71 +50,55 @@ public class NinoBean implements Serializable {
     @PostConstruct
     public void init() {
         nino = new Nino();
-        padre = new Padre();
-        usuarioPadre = new Usuario();
         ninoDAO = new NinoDAO();
         padreDAO = new PadreDAO();
         usuarioDAO = new UsuarioDAO();
         hogarDAO = new HogarComunitarioDAO();
-
-        // cargar hogares activos para combo dinámico
         listaHogares = hogarDAO.listarActivos();
+        cargarPadreDesdeParametros();
+    }
+
+    private void cargarPadreDesdeParametros() {
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        if (ctx == null) {
+            return;
+        }
+        ExternalContext external = ctx.getExternalContext();
+        if (external == null) {
+            return;
+        }
+        Map<String, String> params = external.getRequestParameterMap();
+        if (params == null) {
+            return;
+        }
+        String padreParam = params.get("padreId");
+        if (padreParam == null || padreParam.trim().isEmpty()) {
+            return;
+        }
+        try {
+            padreIdSeleccionado = Integer.valueOf(padreParam.trim());
+            padreSeleccionado = padreDAO.findById(padreIdSeleccionado);
+            if (padreSeleccionado != null && padreSeleccionado.getUsuarioId() != null) {
+                usuarioPadreSeleccionado = usuarioDAO.findById(padreSeleccionado.getUsuarioId());
+            }
+        } catch (NumberFormatException e) {
+            padreIdSeleccionado = null;
+            padreSeleccionado = null;
+            usuarioPadreSeleccionado = null;
+        }
     }
 
     public String guardarMatricula() {
         FacesContext ctx = FacesContext.getCurrentInstance();
         try {
-            // =============================
-            // 1. Validar archivos obligatorios
-            // =============================
+            if (padreIdSeleccionado == null || padreIdSeleccionado <= 0) {
+                throw new RuntimeException("Debes registrar primero los datos del padre.");
+            }
             if (fotoNinoPart == null || fotoNinoPart.getSize() == 0) {
-                throw new RuntimeException("Debe adjuntar la foto del niño.");
-            }
-            if (docPadrePart == null || docPadrePart.getSize() == 0) {
-                throw new RuntimeException("Debe adjuntar el documento del padre.");
+                throw new RuntimeException("Debes adjuntar la foto del niño.");
             }
 
-            // =============================
-            // 2. Validar contraseñas
-            // =============================
-            if (password1 == null || password2 == null || !password1.equals(password2)) {
-                throw new RuntimeException("Contraseñas inválidas o no coinciden.");
-            }
-
-            // =============================
-            // 3. Crear o reutilizar USUARIO del padre
-            // =============================
-            Usuario usuarioExistente = usuarioDAO.findByDocumento(Long.parseLong(usuarioPadre.getDocumento()));
-            int usuarioId;
-            if (usuarioExistente != null) {
-                usuarioId = usuarioExistente.getIdUsuario();
-            } else {
-                int rolPadreId = usuarioDAO.obtenerRolId("padre");
-                usuarioPadre.setRolId(rolPadreId);
-                usuarioPadre.setPasswordHash(sha256(password1));
-                usuarioId = usuarioDAO.insertPadre(usuarioPadre);
-            }
-
-            // =============================
-            // 4. Crear o reutilizar PADRE
-            // =============================
-            Padre padreExistente = padreDAO.findByUsuarioId(usuarioId);
-            int idPadre;
-            if (padreExistente != null) {
-                idPadre = padreExistente.getIdPadre();
-                String rutaDoc = guardarArchivo(docPadrePart, "padres/" + usuarioId);
-                padreDAO.updateDocumento(idPadre, rutaDoc);
-            } else {
-                padre.setUsuarioId(usuarioId);
-                String rutaDoc = guardarArchivo(docPadrePart, "padres/" + usuarioId);
-                padre.setDocumentoIdentidadImg(rutaDoc);
-                idPadre = padreDAO.insert(padre);
-            }
-
-            // =============================
-            // 5. Crear NIÑO
-            // =============================
-            nino.setPadreId(idPadre); // FK al registro del padre en tabla padres
+            nino.setPadreId(padreIdSeleccionado);
             int idNino = ninoDAO.insert(nino);
 
             String rutaFoto = guardarArchivo(fotoNinoPart, "ninos/" + idNino);
@@ -132,44 +109,33 @@ public class NinoBean implements Serializable {
 
             limpiarFormulario();
             cargarNinos();
-
+            return "listarNinos?faces-redirect=true";
         } catch (Exception e) {
             ctx.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR,
                     "Error al guardar: " + e.getMessage(), null));
-            e.printStackTrace();
+            return null;
         }
-        return "listarNinos?faces-redirect=true";
-
     }
 
     private String guardarArchivo(Part part, String carpetaRelativa) throws Exception {
         String nombreOriginal = Paths.get(part.getSubmittedFileName()).getFileName().toString();
-        String ext = nombreOriginal.contains(".") ? nombreOriginal.substring(nombreOriginal.lastIndexOf('.') + 1) : "";
+        String extension = "";
+        int idx = nombreOriginal.lastIndexOf('.');
+        if (idx != -1 && idx < nombreOriginal.length() - 1) {
+            extension = nombreOriginal.substring(idx + 1);
+        }
         String uuid = UUID.randomUUID().toString().replace("-", "");
-        String nuevoNombre = uuid + "." + ext;
+        String nuevoNombre = extension.isEmpty() ? uuid : uuid + "." + extension;
 
         Path destinoDir = Paths.get(BASE_DIR, carpetaRelativa);
         Files.createDirectories(destinoDir);
 
         Path destino = destinoDir.resolve(nuevoNombre);
-
         try (InputStream in = part.getInputStream()) {
             Files.copy(in, destino);
         }
 
-        return carpetaRelativa + "/" + nuevoNombre; // ruta relativa para BD
-    }
-
-    private String sha256(String input) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] hash = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder sb = new StringBuilder();
-            for (byte b : hash) sb.append(String.format("%02x", b));
-            return sb.toString();
-        } catch (Exception e) {
-            throw new RuntimeException("No se pudo calcular SHA-256", e);
-        }
+        return carpetaRelativa + "/" + nuevoNombre;
     }
 
     public void cargarNinos() {
@@ -205,28 +171,23 @@ public class NinoBean implements Serializable {
 
     private void limpiarFormulario() {
         nino = new Nino();
-        padre = new Padre();
-        usuarioPadre = new Usuario();
-        password1 = null;
-        password2 = null;
         fotoNinoPart = null;
-        docPadrePart = null;
     }
-    
+
     public String cancelar() {
-    // Redirige a la página de listado de niños
-    return "listarNinos?faces-redirect=true";
-}
+        return "listarNinos?faces-redirect=true";
+    }
+
     public void cargarNinoPorId() {
         try {
             if (FacesContext.getCurrentInstance().isPostback()) {
-                return; // evitar sobreescribir los datos enviados por el usuario en POST
+                return;
             }
 
             if (nino != null && nino.getIdNino() > 0) {
                 Nino cargado = ninoDAO.buscarNinoPorId(nino.getIdNino());
                 if (cargado != null) {
-                    this.nino = cargado; // reemplazamos el niño con los datos de BD
+                    this.nino = cargado;
                 } else {
                     FacesContext.getCurrentInstance().addMessage(null,
                         new FacesMessage(FacesMessage.SEVERITY_WARN,
@@ -241,61 +202,70 @@ public class NinoBean implements Serializable {
         }
     }
 
+    public String actualizarNino() {
+        try {
+            if (fotoNinoPart != null && fotoNinoPart.getSize() > 0) {
+                String rutaFoto = guardarArchivo(fotoNinoPart, "ninos/" + nino.getIdNino());
+                nino.setFoto(rutaFoto);
+            }
 
-  public String actualizarNino() {
-    try {
-        if (fotoNinoPart != null && fotoNinoPart.getSize() > 0) {
-            String rutaFoto = guardarArchivo(fotoNinoPart, "ninos/" + nino.getIdNino());
-            nino.setFoto(rutaFoto);
-        }
-
-        boolean actualizado = ninoDAO.actualizarNino(nino);
-        if (actualizado) {
+            boolean actualizado = ninoDAO.actualizarNino(nino);
+            if (actualizado) {
+                FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO,
+                    "Niño actualizado correctamente", null));
+                return "listarNinos?faces-redirect=true";
+            } else {
+                FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_WARN,
+                    "No se pudo actualizar el niño", null));
+                return null;
+            }
+        } catch (Exception e) {
             FacesContext.getCurrentInstance().addMessage(null,
-                new FacesMessage(FacesMessage.SEVERITY_INFO,
-                "Niño actualizado correctamente", null));
-            return "listarNinos?faces-redirect=true"; // ✅ vuelve al listado
-        } else {
-            FacesContext.getCurrentInstance().addMessage(null,
-                new FacesMessage(FacesMessage.SEVERITY_WARN,
-                "No se pudo actualizar el niño", null));
-            return null; // ❌ se queda en la misma página
+                new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                "Error al actualizar niño: " + e.getMessage(), null));
+            return null;
         }
-    } catch (Exception e) {
-        FacesContext.getCurrentInstance().addMessage(null,
-            new FacesMessage(FacesMessage.SEVERITY_ERROR,
-            "Error al actualizar niño: " + e.getMessage(), null));
-        return null;
     }
-}
 
+    public Nino getNino() {
+        return nino;
+    }
 
+    public void setNino(Nino nino) {
+        this.nino = nino;
+    }
 
+    public Part getFotoNinoPart() {
+        return fotoNinoPart;
+    }
 
+    public void setFotoNinoPart(Part fotoNinoPart) {
+        this.fotoNinoPart = fotoNinoPart;
+    }
 
+    public Integer getPadreIdSeleccionado() {
+        return padreIdSeleccionado;
+    }
 
+    public void setPadreIdSeleccionado(Integer padreIdSeleccionado) {
+        this.padreIdSeleccionado = padreIdSeleccionado;
+    }
 
-    // Getters y Setters
-    public Nino getNino() { return nino; }
-    public void setNino(Nino nino) { this.nino = nino; }
+    public Padre getPadreSeleccionado() {
+        return padreSeleccionado;
+    }
 
-    public Padre getPadre() { return padre; }
-    public void setPadre(Padre padre) { this.padre = padre; }
+    public Usuario getUsuarioPadreSeleccionado() {
+        return usuarioPadreSeleccionado;
+    }
 
-    public Usuario getUsuarioPadre() { return usuarioPadre; }
-    public void setUsuarioPadre(Usuario usuarioPadre) { this.usuarioPadre = usuarioPadre; }
-
-    public String getPassword1() { return password1; }
-    public void setPassword1(String password1) { this.password1 = password1; }
-
-    public String getPassword2() { return password2; }
-    public void setPassword2(String password2) { this.password2 = password2; }
-
-    public Part getFotoNinoPart() { return fotoNinoPart; }
-    public void setFotoNinoPart(Part fotoNinoPart) { this.fotoNinoPart = fotoNinoPart; }
-
-    public Part getDocPadrePart() { return docPadrePart; }
-    public void setDocPadrePart(Part docPadrePart) { this.docPadrePart = docPadrePart; }
+    public boolean isPadreDisponible() {
+        return padreIdSeleccionado != null
+                && padreSeleccionado != null
+                && usuarioPadreSeleccionado != null;
+    }
 
     public List<Nino> getListaNinos() {
         if (listaNinos == null) {
@@ -303,7 +273,12 @@ public class NinoBean implements Serializable {
         }
         return listaNinos;
     }
-    public void setListaNinos(List<Nino> listaNinos) { this.listaNinos = listaNinos; }
 
-    public List<HogarComunitario> getListaHogares() { return listaHogares; }
+    public void setListaNinos(List<Nino> listaNinos) {
+        this.listaNinos = listaNinos;
+    }
+
+    public List<HogarComunitario> getListaHogares() {
+        return listaHogares;
+    }
 }

--- a/src/java/control/PadreMatriculaBean.java
+++ b/src/java/control/PadreMatriculaBean.java
@@ -1,0 +1,221 @@
+package control;
+
+import dao.PadreDAO;
+import dao.UsuarioDAO;
+import modelo.Padre;
+import modelo.Usuario;
+
+import javax.annotation.PostConstruct;
+import javax.faces.application.FacesMessage;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import javax.faces.context.FacesContext;
+import javax.servlet.http.Part;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.util.UUID;
+
+@ManagedBean(name = "padreMatriculaBean")
+@ViewScoped
+public class PadreMatriculaBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String BASE_DIR = "C:/icbf_uploads";
+
+    private Padre padre;
+    private Usuario usuarioPadre;
+    private String password1;
+    private String password2;
+    private Part documentoPart;
+
+    private transient PadreDAO padreDAO;
+    private transient UsuarioDAO usuarioDAO;
+
+    @PostConstruct
+    public void init() {
+        padre = new Padre();
+        usuarioPadre = new Usuario();
+        padreDAO = new PadreDAO();
+        usuarioDAO = new UsuarioDAO();
+    }
+
+    public String guardarPadre() {
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        try {
+            validarFormulario();
+
+            long documento = Long.parseLong(usuarioPadre.getDocumento().trim());
+            usuarioPadre.setDocumento(String.valueOf(documento));
+            usuarioPadre.setNombres(usuarioPadre.getNombres().trim());
+            usuarioPadre.setApellidos(usuarioPadre.getApellidos().trim());
+            usuarioPadre.setCorreo(usuarioPadre.getCorreo().trim());
+            if (usuarioPadre.getDireccion() != null) {
+                usuarioPadre.setDireccion(usuarioPadre.getDireccion().trim());
+            }
+            if (usuarioPadre.getTelefono() != null) {
+                usuarioPadre.setTelefono(usuarioPadre.getTelefono().trim());
+            }
+
+            String passwordHash = sha256(password1);
+
+            Usuario existente = usuarioDAO.findByDocumento(documento);
+            int usuarioId;
+
+            if (existente == null) {
+                usuarioPadre.setPasswordHash(passwordHash);
+                usuarioId = usuarioDAO.insertPadre(usuarioPadre);
+            } else {
+                usuarioPadre.setIdUsuario(existente.getIdUsuario());
+                usuarioDAO.actualizarDatosPadre(usuarioPadre, passwordHash);
+                usuarioId = existente.getIdUsuario();
+            }
+
+            String rutaDocumento = guardarArchivo(documentoPart, "padres/" + usuarioId);
+
+            Padre padreExistente = padreDAO.findByUsuarioId(usuarioId);
+            int idPadre;
+            if (padre.getOcupacion() != null) {
+                padre.setOcupacion(padre.getOcupacion().trim());
+            }
+            if (padre.getTelefonoContactoEmergencia() != null) {
+                padre.setTelefonoContactoEmergencia(padre.getTelefonoContactoEmergencia().trim());
+            }
+            if (padre.getNombreContactoEmergencia() != null) {
+                padre.setNombreContactoEmergencia(padre.getNombreContactoEmergencia().trim());
+            }
+            if (padre.getSituacionEconomicaHogar() != null) {
+                padre.setSituacionEconomicaHogar(padre.getSituacionEconomicaHogar().trim());
+            }
+            if (padreExistente == null) {
+                padre.setUsuarioId(usuarioId);
+                padre.setDocumentoIdentidadImg(rutaDocumento);
+                idPadre = padreDAO.insert(padre);
+            } else {
+                padre.setIdPadre(padreExistente.getIdPadre());
+                padre.setUsuarioId(usuarioId);
+                padre.setDocumentoIdentidadImg(rutaDocumento);
+                padreDAO.actualizarPadre(padre);
+                idPadre = padreExistente.getIdPadre();
+            }
+
+            ctx.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO,
+                    "Datos del padre guardados correctamente. Continúa con el registro del niño.", null));
+
+            limpiarFormulario();
+            return "crearNino?faces-redirect=true&padreId=" + idPadre;
+        } catch (Exception e) {
+            ctx.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                    "Error al guardar los datos del padre: " + e.getMessage(), null));
+            return null;
+        }
+    }
+
+    private void validarFormulario() {
+        if (usuarioPadre.getDocumento() == null || usuarioPadre.getDocumento().trim().isEmpty()) {
+            throw new IllegalArgumentException("El documento del padre es obligatorio.");
+        }
+        try {
+            Long.parseLong(usuarioPadre.getDocumento().trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("El documento del padre debe ser numérico.");
+        }
+        if (usuarioPadre.getNombres() == null || usuarioPadre.getNombres().trim().isEmpty()) {
+            throw new IllegalArgumentException("Los nombres del padre son obligatorios.");
+        }
+        if (usuarioPadre.getApellidos() == null || usuarioPadre.getApellidos().trim().isEmpty()) {
+            throw new IllegalArgumentException("Los apellidos del padre son obligatorios.");
+        }
+        if (usuarioPadre.getCorreo() == null || usuarioPadre.getCorreo().trim().isEmpty()) {
+            throw new IllegalArgumentException("El correo electrónico es obligatorio.");
+        }
+        if (password1 == null || password2 == null || !password1.equals(password2)) {
+            throw new IllegalArgumentException("Las contraseñas no coinciden.");
+        }
+        if (documentoPart == null || documentoPart.getSize() == 0) {
+            throw new IllegalArgumentException("Debes adjuntar la imagen del documento de identidad.");
+        }
+    }
+
+    private String guardarArchivo(Part part, String carpetaRelativa) throws Exception {
+        String nombreOriginal = Paths.get(part.getSubmittedFileName()).getFileName().toString();
+        String extension = "";
+        int indice = nombreOriginal.lastIndexOf('.');
+        if (indice != -1) {
+            extension = nombreOriginal.substring(indice + 1);
+        }
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        String nuevoNombre = uuid + (extension.isEmpty() ? "" : "." + extension);
+
+        Path destinoDir = Paths.get(BASE_DIR, carpetaRelativa);
+        Files.createDirectories(destinoDir);
+
+        Path destino = destinoDir.resolve(nuevoNombre);
+        try (InputStream in = part.getInputStream()) {
+            Files.copy(in, destino);
+        }
+        return carpetaRelativa + "/" + nuevoNombre;
+    }
+
+    private String sha256(String input) throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        byte[] hash = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        StringBuilder sb = new StringBuilder();
+        for (byte b : hash) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private void limpiarFormulario() {
+        padre = new Padre();
+        usuarioPadre = new Usuario();
+        password1 = null;
+        password2 = null;
+        documentoPart = null;
+    }
+
+    public Padre getPadre() {
+        return padre;
+    }
+
+    public void setPadre(Padre padre) {
+        this.padre = padre;
+    }
+
+    public Usuario getUsuarioPadre() {
+        return usuarioPadre;
+    }
+
+    public void setUsuarioPadre(Usuario usuarioPadre) {
+        this.usuarioPadre = usuarioPadre;
+    }
+
+    public String getPassword1() {
+        return password1;
+    }
+
+    public void setPassword1(String password1) {
+        this.password1 = password1;
+    }
+
+    public String getPassword2() {
+        return password2;
+    }
+
+    public void setPassword2(String password2) {
+        this.password2 = password2;
+    }
+
+    public Part getDocumentoPart() {
+        return documentoPart;
+    }
+
+    public void setDocumentoPart(Part documentoPart) {
+        this.documentoPart = documentoPart;
+    }
+}

--- a/src/java/control/ReporteNinoPdfServlet.java
+++ b/src/java/control/ReporteNinoPdfServlet.java
@@ -155,6 +155,12 @@ public class ReporteNinoPdfServlet extends HttpServlet {
             doc.add(tPadre);
             doc.add(espacio(12f));
 
+            PdfPTable tDocPadre = new PdfPTable(1);
+            tDocPadre.setWidthPercentage(100);
+            addImageCell(tDocPadre, dto.getDocumentoPadreImg(), "Documento de identidad del padre");
+            doc.add(tDocPadre);
+            doc.add(espacio(12f));
+
             // ===== Sección: Credenciales =====
             doc.add(new Paragraph("Credenciales de Acceso", fSeccion));
             doc.add(espacio(6f));

--- a/src/java/dao/PadreDAO.java
+++ b/src/java/dao/PadreDAO.java
@@ -81,4 +81,65 @@ public class PadreDAO {
         }
         return null;
     }
+
+    public Padre findById(int idPadre) {
+        String sql = "SELECT * FROM padres WHERE id_padre = ?";
+        try (Connection con = ConDB.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setInt(1, idPadre);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Padre p = new Padre();
+                    p.setIdPadre(rs.getInt("id_padre"));
+                    p.setUsuarioId(rs.getInt("usuario_id"));
+                    p.setOcupacion(rs.getString("ocupacion"));
+                    Object estratoObj = rs.getObject("estrato");
+                    if (estratoObj instanceof Number) {
+                        p.setEstrato(((Number) estratoObj).intValue());
+                    } else {
+                        p.setEstrato(null);
+                    }
+                    p.setTelefonoContactoEmergencia(rs.getString("telefono_contacto_emergencia"));
+                    p.setNombreContactoEmergencia(rs.getString("nombre_contacto_emergencia"));
+                    p.setSituacionEconomicaHogar(rs.getString("situacion_economica_hogar"));
+                    p.setDocumentoIdentidadImg(rs.getString("documento_identidad_img"));
+                    return p;
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public void actualizarPadre(Padre padre) throws SQLException {
+        String sql = "UPDATE padres SET ocupacion = ?, estrato = ?, telefono_contacto_emergencia = ?, " +
+                     "nombre_contacto_emergencia = ?, situacion_economica_hogar = ?, documento_identidad_img = ?, " +
+                     "usuario_id = ? WHERE id_padre = ?";
+
+        try (Connection con = ConDB.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+
+            ps.setString(1, padre.getOcupacion());
+
+            if (padre.getEstrato() != null) {
+                ps.setInt(2, padre.getEstrato());
+            } else {
+                ps.setNull(2, Types.INTEGER);
+            }
+
+            ps.setString(3, padre.getTelefonoContactoEmergencia());
+            ps.setString(4, padre.getNombreContactoEmergencia());
+            ps.setString(5, padre.getSituacionEconomicaHogar());
+            ps.setString(6, padre.getDocumentoIdentidadImg());
+            if (padre.getUsuarioId() != null) {
+                ps.setInt(7, padre.getUsuarioId());
+            } else {
+                ps.setNull(7, Types.INTEGER);
+            }
+            ps.setInt(8, padre.getIdPadre());
+
+            ps.executeUpdate();
+        }
+    }
 }

--- a/src/java/dao/ReporteDAO.java
+++ b/src/java/dao/ReporteDAO.java
@@ -11,9 +11,11 @@ public class ReporteDAO {
 
     // Buscar un solo reporte por id de niño
     public ReporteNinoDTO findById(int idNino) {
-        String sql = "SELECT vw.*, u.password_hash AS padre_password_hash " +
+        String sql = "SELECT vw.*, u.password_hash AS padre_password_hash, " +
+                     "p.documento_identidad_img AS padre_documento_img " +
                      "FROM vw_reporte_nino vw " +
                      "JOIN usuarios u ON vw.padre_usuario_id = u.id_usuario " +
+                     "JOIN padres p ON p.id_padre = vw.id_padre " +
                      "WHERE vw.id_nino = ?";
         try (Connection con = ConDB.getConnection();
              PreparedStatement ps = con.prepareStatement(sql)) {
@@ -33,9 +35,11 @@ public class ReporteDAO {
     // Listar todos los reportes (o por hogar si quieres)
     public List<ReporteNinoDTO> findAll() {
         List<ReporteNinoDTO> lista = new ArrayList<>();
-        String sql = "SELECT vw.*, u.password_hash AS padre_password_hash " +
+        String sql = "SELECT vw.*, u.password_hash AS padre_password_hash, " +
+                     "p.documento_identidad_img AS padre_documento_img " +
                      "FROM vw_reporte_nino vw " +
-                     "JOIN usuarios u ON vw.padre_usuario_id = u.id_usuario";
+                     "JOIN usuarios u ON vw.padre_usuario_id = u.id_usuario " +
+                     "JOIN padres p ON p.id_padre = vw.id_padre";
         try (Connection con = ConDB.getConnection();
              PreparedStatement ps = con.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {
@@ -81,6 +85,7 @@ public class ReporteDAO {
         dto.setNomEmerg(rs.getString("nombre_contacto_emergencia"));
         dto.setSituacionEcon(rs.getString("situacion_economica_hogar"));
         dto.setPadrePasswordHash(rs.getString("padre_password_hash"));
+        dto.setDocumentoPadreImg(rs.getString("padre_documento_img"));
 
         // Hogar
         dto.setIdHogar(rs.getInt("id_hogar"));

--- a/src/java/modelo/ReporteNinoDTO.java
+++ b/src/java/modelo/ReporteNinoDTO.java
@@ -32,6 +32,7 @@ public class ReporteNinoDTO {
     private String nomEmerg;
     private String situacionEcon;
     private String padrePasswordHash;
+    private String documentoPadreImg;
 
     // Hogar
     private int idHogar;
@@ -114,6 +115,9 @@ public class ReporteNinoDTO {
 
     public String getPadrePasswordHash() { return padrePasswordHash; }
     public void setPadrePasswordHash(String padrePasswordHash) { this.padrePasswordHash = padrePasswordHash; }
+
+    public String getDocumentoPadreImg() { return documentoPadreImg; }
+    public void setDocumentoPadreImg(String documentoPadreImg) { this.documentoPadreImg = documentoPadreImg; }
 
     public int getIdHogar() { return idHogar; }
     public void setIdHogar(int idHogar) { this.idHogar = idHogar; }

--- a/web/ReporteDetalle.xhtml
+++ b/web/ReporteDetalle.xhtml
@@ -24,7 +24,9 @@
             <h:outputText value="#{reporteBean.seleccionado.ninoDocumento}" />
 
             <h:outputLabel value="Fecha Nacimiento:" />
-            <h:outputText value="#{reporteBean.seleccionado.fechaNacimiento}" />
+            <h:outputText value="#{reporteBean.seleccionado.fechaNacimiento}">
+                <f:convertDateTime pattern="dd/MM/yyyy" />
+            </h:outputText>
 
             <h:outputLabel value="Género:" />
             <h:outputText value="#{reporteBean.seleccionado.genero}" />
@@ -33,16 +35,21 @@
             <h:outputText value="#{reporteBean.seleccionado.nacionalidad}" />
 
             <h:outputLabel value="Fecha Ingreso:" />
-            <h:outputText value="#{reporteBean.seleccionado.fechaIngreso}" />
+            <h:outputText value="#{reporteBean.seleccionado.fechaIngreso}">
+                <f:convertDateTime pattern="dd/MM/yyyy" />
+            </h:outputText>
 
             <h:outputLabel value="Foto:" />
-            <h:graphicImage value="/icbf_uploads/#{reporteBean.seleccionado.foto}" width="120" height="120" />
+            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.foto}" width="120" height="120" rendered="#{not empty reporteBean.seleccionado.foto}" />
+            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.foto}" />
 
             <h:outputLabel value="Carnet Vacunación:" />
-            <h:graphicImage value="/icbf_uploads/#{reporteBean.seleccionado.carnetVacunacion}" width="120" height="120" />
+            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.carnetVacunacion}" width="120" height="120" rendered="#{not empty reporteBean.seleccionado.carnetVacunacion}" />
+            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.carnetVacunacion}" />
 
             <h:outputLabel value="Certificado EPS:" />
-            <h:graphicImage value="/icbf_uploads/#{reporteBean.seleccionado.certificadoEps}" width="120" height="120" />
+            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.certificadoEps}" width="120" height="120" rendered="#{not empty reporteBean.seleccionado.certificadoEps}" />
+            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.certificadoEps}" />
 
             <!-- Datos del padre -->
             <h:outputLabel value="Padre:" />
@@ -74,6 +81,13 @@
 
             <h:outputLabel value="Situación Económica:" />
             <h:outputText value="#{reporteBean.seleccionado.situacionEcon}" />
+
+            <h:outputLabel value="Documento identidad padre:" />
+            <h:panelGroup>
+                <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.documentoPadreImg}"
+                                width="120" height="120" rendered="#{not empty reporteBean.seleccionado.documentoPadreImg}" />
+                <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.documentoPadreImg}" />
+            </h:panelGroup>
 
             <h:outputLabel value="ID interno usuario:" />
             <h:outputText value="#{reporteBean.seleccionado.padreUsuarioId eq 0 ? '-' : reporteBean.seleccionado.padreUsuarioId}" />

--- a/web/crearNino.xhtml
+++ b/web/crearNino.xhtml
@@ -11,9 +11,57 @@
 <h:form enctype="multipart/form-data">
     <h:messages globalOnly="true" style="color:red;" />
 
-    <!-- ====================== -->
-    <!-- DATOS DEL NIÑO -->
-    <!-- ====================== -->
+    <h2>Datos del Padre Registrado</h2>
+    <h:panelGroup rendered="#{ninoBean.padreDisponible}">
+        <h:panelGrid columns="2" columnClasses="label,value" styleClass="resumen-padre">
+            <h:outputLabel value="ID Padre:" />
+            <h:outputText value="#{ninoBean.padreIdSeleccionado}" />
+
+            <h:outputLabel value="Nombres:" />
+            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.nombres} #{ninoBean.usuarioPadreSeleccionado.apellidos}" />
+
+            <h:outputLabel value="Documento:" />
+            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.documento}" />
+
+            <h:outputLabel value="Correo:" />
+            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.correo}" />
+
+            <h:outputLabel value="Teléfono:" />
+            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.telefono}" />
+
+            <h:outputLabel value="Dirección:" />
+            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.direccion}" />
+
+            <h:outputLabel value="Ocupación:" />
+            <h:outputText value="#{ninoBean.padreSeleccionado.ocupacion}" />
+
+            <h:outputLabel value="Estrato:" />
+            <h:outputText value="#{ninoBean.padreSeleccionado.estrato}" />
+
+            <h:outputLabel value="Contacto emergencia:" />
+            <h:outputText value="#{ninoBean.padreSeleccionado.nombreContactoEmergencia} / #{ninoBean.padreSeleccionado.telefonoContactoEmergencia}" />
+
+            <h:outputLabel value="Situación económica:" />
+            <h:outputText value="#{ninoBean.padreSeleccionado.situacionEconomicaHogar}" />
+
+            <h:outputLabel value="Documento identidad:" />
+            <h:panelGroup>
+                <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{ninoBean.padreSeleccionado.documentoIdentidadImg}"
+                                width="120" height="120" rendered="#{not empty ninoBean.padreSeleccionado.documentoIdentidadImg}" />
+                <h:outputText value="No disponible" rendered="#{empty ninoBean.padreSeleccionado.documentoIdentidadImg}" />
+            </h:panelGroup>
+        </h:panelGrid>
+    </h:panelGroup>
+    <h:panelGroup rendered="#{!ninoBean.padreDisponible}" style="color:#c0392b; font-weight:bold;">
+        <h:outputText value="Debes registrar primero los datos del padre antes de matricular al niño." />
+        <br/>
+        <h:link outcome="crearPadre" value="Registrar datos del padre" />
+    </h:panelGroup>
+
+    <h:inputHidden value="#{ninoBean.padreIdSeleccionado}" />
+
+    <p:separator/>
+
     <h2>Datos del Niño</h2>
     <h:panelGrid columns="2" columnClasses="label,value">
 
@@ -28,18 +76,17 @@
 
         <h:outputLabel for="fechaNac" value="Fecha de nacimiento:" />
         <div class="form-field">
-                    <h:outputLabel for="fechaNac" value="Fecha de nacimiento" styleClass="field-label"/>
-                    <p:calendar id="fechaNac"
-                                value="#{ninoBean.nino.fechaNacimiento}"
-                                pattern="yyyy-MM-dd"
-                                
-                                navigator="true"
-                                yearRange="1950:2100"
-                                required="true"
-                                requiredMessage="Selecciona la fecha de nacimiento."
-                                inputStyleClass="input-field"/>
-                    <h:message for="fechaNac" styleClass="error-msg"/>
-                </div>
+            <h:outputLabel for="fechaNac" value="Fecha de nacimiento" styleClass="field-label"/>
+            <p:calendar id="fechaNac"
+                        value="#{ninoBean.nino.fechaNacimiento}"
+                        pattern="yyyy-MM-dd"
+                        navigator="true"
+                        yearRange="1950:2100"
+                        required="true"
+                        requiredMessage="Selecciona la fecha de nacimiento."
+                        inputStyleClass="input-field"/>
+            <h:message for="fechaNac" styleClass="error-msg"/>
+        </div>
 
         <h:outputLabel for="genero" value="Género:" />
         <h:selectOneMenu id="genero" value="#{ninoBean.nino.genero}">
@@ -68,69 +115,16 @@
 
     <p:separator/>
 
-    <!-- ====================== -->
-    <!-- DATOS DEL PADRE -->
-    <!-- ====================== -->
-    <h2>Datos del Padre</h2>
-    <h:panelGrid columns="2" columnClasses="label,value">
-
-        <h:outputLabel for="nombresP" value="Nombres:" />
-        <h:inputText id="nombresP" value="#{ninoBean.usuarioPadre.nombres}" required="true" />
-
-        <h:outputLabel for="apellidosP" value="Apellidos:" />
-        <h:inputText id="apellidosP" value="#{ninoBean.usuarioPadre.apellidos}" required="true" />
-
-        <h:outputLabel for="documentoP" value="Documento:" />
-        <h:inputText id="documentoP" value="#{ninoBean.usuarioPadre.documento}" required="true" />
-
-        <h:outputLabel for="ocupacion" value="Ocupación:" />
-        <h:inputText id="ocupacion" value="#{ninoBean.padre.ocupacion}" />
-
-        <h:outputLabel for="estrato" value="Estrato:" />
-        <h:inputText id="estrato" value="#{ninoBean.padre.estrato}" />
-
-        <h:outputLabel for="telEmerg" value="Teléfono de emergencia:" />
-        <h:inputText id="telEmerg" value="#{ninoBean.padre.telefonoContactoEmergencia}" />
-
-        <h:outputLabel for="nomEmerg" value="Nombre contacto de emergencia:" />
-        <h:inputText id="nomEmerg" value="#{ninoBean.padre.nombreContactoEmergencia}" />
-
-        <h:outputLabel for="sitEcon" value="Situación económica hogar:" />
-        <h:inputTextarea id="sitEcon" value="#{ninoBean.padre.situacionEconomicaHogar}" rows="3" cols="30" />
-
-        <h:outputLabel for="docPadre" value="Documento de identidad (archivo):" />
-        <h:inputFile id="docPadre" value="#{ninoBean.docPadrePart}" required="true" />
-
-        <h:outputLabel for="correoP" value="Correo electrónico:" />
-        <h:inputText id="correoP" value="#{ninoBean.usuarioPadre.correo}" required="true" />
-
-        <h:outputLabel for="direccionP" value="Dirección:" />
-        <h:inputText id="direccionP" value="#{ninoBean.usuarioPadre.direccion}" />
-
-        <h:outputLabel for="telefonoP" value="Teléfono:" />
-        <h:inputText id="telefonoP" value="#{ninoBean.usuarioPadre.telefono}" />
-
-        <h:outputLabel for="pass1" value="Contraseña:" />
-        <h:inputSecret id="pass1" value="#{ninoBean.password1}" required="true" redisplay="true"/>
-
-        <h:outputLabel for="pass2" value="Confirmar contraseña:" />
-        <h:inputSecret id="pass2" value="#{ninoBean.password2}" required="true" redisplay="true"/>
-
-    </h:panelGrid>
-
-    <p:separator/>
-
-    <!-- BOTONES -->
-<p:commandButton value="Guardar Matrícula"
-                 action="#{NinoBean.guardarMatricula}"
-                 ajax="false"
-                 styleClass="ui-button-success"/>
-
+    <p:commandButton value="Guardar Matrícula"
+                     action="#{ninoBean.guardarMatricula}"
+                     ajax="false"
+                     styleClass="ui-button-success"
+                     disabled="#{!ninoBean.padreDisponible}"/>
 
     <p:commandButton value="Cancelar" immediate="true"
-                     action="#{NinoBean.cancelar}"
+                     action="#{ninoBean.cancelar}"
                      styleClass="ui-button-secondary"/>
-   
+
 </h:form>
 
 </h:body>

--- a/web/crearPadre.xhtml
+++ b/web/crearPadre.xhtml
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+<h:head>
+    <title>Registrar Padre / Acudiente</title>
+</h:head>
+<h:body>
+
+<h:form enctype="multipart/form-data">
+    <p:messages showDetail="true" showSummary="false" closable="true" />
+
+    <h2>Datos del Usuario Padre</h2>
+    <h:panelGrid columns="2" columnClasses="label,value">
+        <h:outputLabel for="nombresP" value="Nombres:" />
+        <h:inputText id="nombresP" value="#{padreMatriculaBean.usuarioPadre.nombres}" required="true" />
+
+        <h:outputLabel for="apellidosP" value="Apellidos:" />
+        <h:inputText id="apellidosP" value="#{padreMatriculaBean.usuarioPadre.apellidos}" required="true" />
+
+        <h:outputLabel for="documentoP" value="Documento:" />
+        <h:inputText id="documentoP" value="#{padreMatriculaBean.usuarioPadre.documento}" required="true" />
+
+        <h:outputLabel for="correoP" value="Correo electrónico:" />
+        <h:inputText id="correoP" value="#{padreMatriculaBean.usuarioPadre.correo}" required="true" />
+
+        <h:outputLabel for="direccionP" value="Dirección:" />
+        <h:inputText id="direccionP" value="#{padreMatriculaBean.usuarioPadre.direccion}" />
+
+        <h:outputLabel for="telefonoP" value="Teléfono:" />
+        <h:inputText id="telefonoP" value="#{padreMatriculaBean.usuarioPadre.telefono}" />
+
+        <h:outputLabel for="pass1" value="Contraseña:" />
+        <h:inputSecret id="pass1" value="#{padreMatriculaBean.password1}" required="true" redisplay="true" />
+
+        <h:outputLabel for="pass2" value="Confirmar contraseña:" />
+        <h:inputSecret id="pass2" value="#{padreMatriculaBean.password2}" required="true" redisplay="true" />
+    </h:panelGrid>
+
+    <p:separator/>
+
+    <h2>Información Complementaria</h2>
+    <h:panelGrid columns="2" columnClasses="label,value">
+        <h:outputLabel for="ocupacion" value="Ocupación:" />
+        <h:inputText id="ocupacion" value="#{padreMatriculaBean.padre.ocupacion}" />
+
+        <h:outputLabel for="estrato" value="Estrato:" />
+        <h:inputText id="estrato" value="#{padreMatriculaBean.padre.estrato}">
+            <f:convertNumber integerOnly="true" />
+        </h:inputText>
+
+        <h:outputLabel for="telEmerg" value="Teléfono emergencia:" />
+        <h:inputText id="telEmerg" value="#{padreMatriculaBean.padre.telefonoContactoEmergencia}" />
+
+        <h:outputLabel for="nomEmerg" value="Nombre contacto emergencia:" />
+        <h:inputText id="nomEmerg" value="#{padreMatriculaBean.padre.nombreContactoEmergencia}" />
+
+        <h:outputLabel for="sitEcon" value="Situación económica hogar:" />
+        <h:inputTextarea id="sitEcon" value="#{padreMatriculaBean.padre.situacionEconomicaHogar}" rows="3" cols="30" />
+
+        <h:outputLabel for="docPadre" value="Documento de identidad (imagen):" />
+        <h:inputFile id="docPadre" value="#{padreMatriculaBean.documentoPart}" required="true" />
+    </h:panelGrid>
+
+    <p:separator/>
+
+    <p:commandButton value="Guardar y continuar"
+                     action="#{padreMatriculaBean.guardarPadre}"
+                     ajax="false"
+                     styleClass="ui-button-success" />
+
+    <p:commandButton value="Cancelar" immediate="true"
+                     action="listarNinos?faces-redirect=true"
+                     styleClass="ui-button-secondary" />
+</h:form>
+
+</h:body>
+</html>

--- a/web/listarNinos.xhtml
+++ b/web/listarNinos.xhtml
@@ -84,7 +84,7 @@
 
         <!-- Botones de navegación -->
         <p:commandButton value="Registrar Nuevo Niño"
-                         action="crearNino?faces-redirect=true"
+                         action="crearPadre?faces-redirect=true"
                          icon="pi pi-plus"
                          ajax="false" />
 


### PR DESCRIPTION
## Summary
- crear un flujo previo de registro del padre con un nuevo bean y formulario dedicado
- ajustar el bean y la vista de matrícula de niños para reutilizar al padre registrado y mostrar sus datos
- ampliar los reportes y el PDF para incluir la imagen del documento del padre y los nuevos accesos a datos

## Testing
- ant -f build.xml compile *(falla: comando ant no disponible en el contenedor)*

------
https://chatgpt.com/codex/tasks/task_b_68d1cfeb00088332be17927b1a3de290