### PR TITLE
Fix administrator mother account creation flow

### DIFF
--- a/src/java/control/MadreComunitariaBean.java
+++ b/src/java/control/MadreComunitariaBean.java
@@ -5,8 +5,10 @@ import modelo.Usuario;
 
 import java.io.Serializable;
 import java.util.List;
+import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
+import javax.faces.context.FacesContext;
 
 @ManagedBean(name = "madreBean")
 @SessionScoped
@@ -40,11 +42,18 @@ public class MadreComunitariaBean implements Serializable {
 
     // Crear nueva madre
     public String guardarMadre() {
+        FacesContext context = FacesContext.getCurrentInstance();
+
         if (usuarioDAO.crearMadre(madre, passwordPlano)) {
             madre = new Usuario();
-            passwordPlano = "";
+            passwordPlano = null;
             return "listarMadres?faces-redirect=true";
         }
+
+        context.addMessage(null, new FacesMessage(
+                FacesMessage.SEVERITY_ERROR,
+                "No se pudo registrar la madre comunitaria",
+                "Verifica que el documento y el correo no estén registrados y que la contraseña sea válida."));
         return null;
     }
 

--- a/src/java/dao/UsuarioDAO.java
+++ b/src/java/dao/UsuarioDAO.java
@@ -88,8 +88,27 @@ public class UsuarioDAO {
     // Crear madre comunitaria
     // ========================
     public boolean crearMadre(Usuario madre, String passwordPlano) {
+        if (madre == null) {
+            Logger.getLogger(UsuarioDAO.class.getName())
+                    .warning("No se recibió información de la madre a registrar");
+            return false;
+        }
+
+        if (passwordPlano == null || passwordPlano.trim().isEmpty()) {
+            Logger.getLogger(UsuarioDAO.class.getName())
+                    .warning("La contraseña enviada para la madre comunitaria es inválida");
+            return false;
+        }
+
+        Integer rolMadreId = obtenerRolId("madre_comunitaria");
+        if (rolMadreId == null) {
+            Logger.getLogger(UsuarioDAO.class.getName())
+                    .severe("No existe el rol 'madre_comunitaria' en la base de datos");
+            return false;
+        }
+
         String sql = "INSERT INTO usuarios (documento, nombres, apellidos, correo, direccion, telefono, password_hash, rol_id) "
-                   + "VALUES (?, ?, ?, ?, ?, ?, SHA2(?,256), (SELECT id_rol FROM roles WHERE nombre_rol='madre_comunitaria'))";
+                   + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
         try (Connection con = ConDB.getConnection();
              PreparedStatement ps = con.prepareStatement(sql)) {
@@ -100,12 +119,14 @@ public class UsuarioDAO {
             ps.setString(4, madre.getCorreo());
             ps.setString(5, madre.getDireccion());
             ps.setString(6, madre.getTelefono());
-            ps.setString(7, passwordPlano);
+            ps.setString(7, sha256(passwordPlano));
+            ps.setInt(8, rolMadreId);
 
             return ps.executeUpdate() > 0;
 
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (SQLException e) {
+            Logger.getLogger(UsuarioDAO.class.getName())
+                  .log(Level.SEVERE, "Error al crear madre comunitaria", e);
             return false;
         }
     }

--- a/web/crearMadre.xhtml
+++ b/web/crearMadre.xhtml
@@ -116,6 +116,26 @@
             text-align: center;
         }
 
+        .form-messages {
+            max-width: 1100px;
+            margin: 0 auto 20px;
+            padding: 12px 20px;
+            border-radius: 10px;
+            background-color: rgba(255, 235, 238, 0.95);
+            border-left: 6px solid #d9534f;
+            color: #a94442;
+            font-weight: bold;
+        }
+
+        .form-messages ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        .form-messages li {
+            list-style: none;
+        }
+
         label {
             display: block;
             font-weight: bold;
@@ -231,42 +251,43 @@
 
     <!-- FORMULARIO -->
     <h:form id="formMadre">
-    <div class="form-wrapper">
-        <!-- izquierda -->
-        <div class="form-card">
-            <h3>Información Personal</h3>
+        <h:messages id="messages" globalOnly="true" layout="unorderedList" styleClass="form-messages" />
+        <div class="form-wrapper">
+            <!-- izquierda -->
+            <div class="form-card">
+                <h3>Información Personal</h3>
 
-            <label for="doc">Documento:</label>
-            <h:inputText id="doc" value="#{madreBean.madre.documento}" required="true">
-                <f:validateLength minimum="5" />
+                <label for="doc">Documento:</label>
+                <h:inputText id="doc" value="#{madreBean.madre.documento}" required="true">
+                    <f:validateLength minimum="5" />
+                </h:inputText>
                 <h:message for="doc" style="color:red" />
-            </h:inputText>
 
-            <label for="nombres">Nombres:</label>
-            <h:inputText id="nombres" value="#{madreBean.madre.nombres}" required="true" />
-            <h:message for="nombres" style="color:red" />
+                <label for="nombres">Nombres:</label>
+                <h:inputText id="nombres" value="#{madreBean.madre.nombres}" required="true" />
+                <h:message for="nombres" style="color:red" />
 
-            <label for="apellidos">Apellidos:</label>
-            <h:inputText id="apellidos" value="#{madreBean.madre.apellidos}" required="true" />
-            <h:message for="apellidos" style="color:red" />
+                <label for="apellidos">Apellidos:</label>
+                <h:inputText id="apellidos" value="#{madreBean.madre.apellidos}" required="true" />
+                <h:message for="apellidos" style="color:red" />
 
-            <label for="correo">Correo:</label>
-            <h:inputText id="correo" value="#{madreBean.madre.correo}" required="true">
-                <!-- Validar formato correo -->
-                <f:validateRegex pattern="^[\w.-]+@([\w-]+\.)+[\w-]{2,4}$" />
-            </h:inputText>
-            <h:message for="correo" style="color:red" />
-        </div>
+                <label for="correo">Correo:</label>
+                <h:inputText id="correo" value="#{madreBean.madre.correo}" required="true">
+                    <!-- Validar formato correo -->
+                    <f:validateRegex pattern="^[\w.-]+@([\w-]+\.)+[\w-]{2,4}$" />
+                </h:inputText>
+                <h:message for="correo" style="color:red" />
+            </div>
 
-        <!-- derecha -->
-        <div class="form-card">
-            <h3>Contacto y Acceso</h3>
+            <!-- derecha -->
+            <div class="form-card">
+                <h3>Contacto y Acceso</h3>
 
-            <label for="direccion">Dirección:</label>
-            <h:inputText id="direccion" value="#{madreBean.madre.direccion}" />
+                <label for="direccion">Dirección:</label>
+                <h:inputText id="direccion" value="#{madreBean.madre.direccion}" />
 
-            <label for="tel">Teléfono:</label>
-            <h:inputText id="tel" value="#{madreBean.madre.telefono}" />
+                <label for="tel">Teléfono:</label>
+                <h:inputText id="tel" value="#{madreBean.madre.telefono}" />
 
                 <label for="pass">Contraseña:</label>
                 <h:inputSecret id="pass" value="#{madreBean.passwordPlano}" required="true"
@@ -274,16 +295,14 @@
                     <f:validateRegex pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$" />
                 </h:inputSecret>
                 <h:message for="pass" style="color:red" />
-
-
+            </div>
         </div>
-    </div>
 
-    <div class="button-group">
-        <h:commandButton value="Guardar" action="#{madreBean.guardarMadre}" styleClass="btn-guardar" />
-        <h:link outcome="listarMadres" styleClass="btn-volver">← Volver a la Lista</h:link>
-    </div>
-</h:form>
+        <div class="button-group">
+            <h:commandButton value="Guardar" action="#{madreBean.guardarMadre}" styleClass="btn-guardar" />
+            <h:link outcome="listarMadres" styleClass="btn-volver">← Volver a la Lista</h:link>
+        </div>
+    </h:form>
 
 </h:body>
 </html>


### PR DESCRIPTION
## Summary
- validate the incoming data when creating a madre comunitaria, compute the password hash in Java and resolve the role id explicitly before inserting the user record
- show a descriptive JSF error message when el registro de la madre falla and reset the bean state after a successful alta
- surface the global message area and tidy the form markup on la vista de registro para que el administrador vea los errores de validación

## Testing
- ant -f build.xml compile *(fails: `ant` no está disponible en el entorno de ejecución)*

------
https://chatgpt.com/codex/tasks/task_b_68d1e1ad83b4833297b460d1db925bb4