### PR TITLE
Implementar carga de asistencias por Excel y filtrar por madre

### DIFF
--- a/src/java/control/AsistenciaBean.java
+++ b/src/java/control/AsistenciaBean.java
@@ -2,31 +2,70 @@ package control;
 
 
 import dao.AsistenciaDAO;
+import dao.HogarComunitarioDAO;
 import dao.NinoDAO;
+import dao.UsuarioDAO;
+import modelo.Asistencia;
+import modelo.HogarComunitario;
+import modelo.Nino;
+import modelo.Usuario;
+
+import java.io.InputStream;
 import java.io.Serializable;
 import java.sql.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
+import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.SessionScoped;
-import modelo.Asistencia;
-import modelo.Nino;
+import javax.faces.context.FacesContext;
+import javax.servlet.http.Part;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 
 // AsistenciaBean.java
 @ManagedBean
 @SessionScoped
 public class AsistenciaBean implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
+    private final AsistenciaDAO asistenciaDAO = new AsistenciaDAO();
+    private final NinoDAO ninoDAO = new NinoDAO();
+    private final UsuarioDAO usuarioDAO = new UsuarioDAO();
+    private final HogarComunitarioDAO hogarDAO = new HogarComunitarioDAO();
+    private transient DataFormatter dataFormatter = new DataFormatter();
+
     private Asistencia asistencia = new Asistencia();
-    private AsistenciaDAO asistenciaDAO = new AsistenciaDAO();
-    private NinoDAO ninoDAO = new NinoDAO();
+    private Part archivoExcel;
+
+    @ManagedProperty(value = "#{sessionBean}")
+    private SessionBean sessionBean;
 
     // Lista de asistencias
     public List<Asistencia> getLista() {
+        Usuario usuario = obtenerUsuarioSesion();
+        if (usuario != null && "madre_comunitaria".equals(usuario.getRol())) {
+            return asistenciaDAO.listarPorMadre(usuario.getIdUsuario());
+        }
         return asistenciaDAO.listarConNombres();
     }
 
     // Lista de niños para el combo
     public List<Nino> getNinos() {
+        Usuario usuario = obtenerUsuarioSesion();
+        if (usuario != null && "madre_comunitaria".equals(usuario.getRol())) {
+            return ninoDAO.listarPorMadre(usuario.getIdUsuario());
+        }
         return ninoDAO.listar();
     }
 
@@ -36,6 +75,211 @@ public class AsistenciaBean implements Serializable {
         asistenciaDAO.insertar(asistencia);
         asistencia = new Asistencia(); // limpiar
         return "listarAsistencia?faces-redirect=true";
+    }
+
+    // ==========================
+    // Carga masiva desde Excel
+    // ==========================
+    public void cargarDesdeExcel() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (archivoExcel == null || archivoExcel.getSize() == 0) {
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                    "Debes seleccionar un archivo Excel (.xls o .xlsx).", null));
+            return;
+        }
+
+        Usuario usuarioSesion = obtenerUsuarioSesion();
+        boolean esMadreSesion = usuarioSesion != null && "madre_comunitaria".equals(usuarioSesion.getRol());
+
+        int procesadas = 0;
+        int exitosas = 0;
+        List<String> errores = new ArrayList<>();
+
+        try (InputStream in = archivoExcel.getInputStream();
+             Workbook workbook = WorkbookFactory.create(in)) {
+
+            if (workbook.getNumberOfSheets() == 0) {
+                context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                        "El archivo no contiene hojas para procesar.", null));
+                return;
+            }
+
+            Sheet sheet = workbook.getSheetAt(0);
+            for (int i = 1; i <= sheet.getLastRowNum(); i++) { // Se omite la fila de encabezados
+                Row row = sheet.getRow(i);
+                if (row == null || esFilaVacia(row)) {
+                    continue;
+                }
+
+                procesadas++;
+                try {
+                    String documentoMadreStr = obtenerString(row.getCell(0));
+                    String documentoNinoStr = obtenerString(row.getCell(1));
+                    Date fecha = obtenerFecha(row.getCell(2));
+                    String estado = normalizarEstado(obtenerString(row.getCell(3)));
+
+                    if (documentoNinoStr == null || documentoNinoStr.isEmpty()) {
+                        throw new IllegalArgumentException("El documento del niño es obligatorio.");
+                    }
+
+                    Usuario madre;
+                    if (esMadreSesion) {
+                        madre = usuarioSesion;
+                        String documentoSesion = madre.getDocumento() != null ? madre.getDocumento().trim() : "";
+                        if (documentoMadreStr != null && !documentoMadreStr.isEmpty()
+                                && !documentoSesion.equals(documentoMadreStr.trim())) {
+                            throw new IllegalArgumentException("El documento de la madre en el archivo no coincide con el usuario logueado.");
+                        }
+                    } else {
+                        if (documentoMadreStr == null || documentoMadreStr.isEmpty()) {
+                            throw new IllegalArgumentException("El documento de la madre es obligatorio.");
+                        }
+                        madre = buscarMadrePorDocumento(documentoMadreStr);
+                        if (madre == null) {
+                            throw new IllegalArgumentException("No se encontró una madre con documento " + documentoMadreStr + ".");
+                        }
+                    }
+
+                    HogarComunitario hogar = hogarDAO.buscarPorMadre(madre.getIdUsuario());
+                    if (hogar == null) {
+                        throw new IllegalArgumentException("La madre indicada no tiene un hogar asignado.");
+                    }
+
+                    Nino nino = buscarNinoPorDocumento(documentoNinoStr);
+                    if (nino == null) {
+                        throw new IllegalArgumentException("No se encontró un niño con documento " + documentoNinoStr + ".");
+                    }
+
+                    if (nino.getHogarId() != hogar.getIdHogar()) {
+                        throw new IllegalArgumentException("El niño no pertenece al hogar de la madre indicada.");
+                    }
+
+                    Asistencia registro = new Asistencia();
+                    registro.setIdNino(nino.getIdNino());
+                    registro.setFecha(fecha);
+                    registro.setEstado(estado);
+
+                    if (asistenciaDAO.insertar(registro)) {
+                        exitosas++;
+                    } else {
+                        throw new IllegalStateException("No se pudo guardar la asistencia del niño " + documentoNinoStr + ".");
+                    }
+                } catch (Exception e) {
+                    errores.add("Fila " + (i + 1) + ": " + e.getMessage());
+                }
+            }
+
+        } catch (Exception e) {
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                    "Error al procesar el archivo: " + e.getMessage(), null));
+            return;
+        } finally {
+            archivoExcel = null;
+        }
+
+        if (procesadas == 0) {
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_WARN,
+                    "No se encontraron registros para importar.", null));
+        } else {
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO,
+                    "Importación finalizada: " + exitosas + " de " + procesadas + " registros importados.", null));
+        }
+
+        for (String error : errores) {
+            context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_WARN, error, null));
+        }
+    }
+
+    private Usuario obtenerUsuarioSesion() {
+        return sessionBean != null ? sessionBean.getUsuarioLogueado() : null;
+    }
+
+    private Usuario buscarMadrePorDocumento(String documento) {
+        long documentoMadre = parsearDocumento(documento, "de la madre");
+        return usuarioDAO.findByDocumento(documentoMadre);
+    }
+
+    private Nino buscarNinoPorDocumento(String documento) {
+        long documentoNino = parsearDocumento(documento, "del niño");
+        return ninoDAO.buscarPorDocumento(documentoNino);
+    }
+
+    private long parsearDocumento(String valor, String etiqueta) {
+        try {
+            return Long.parseLong(valor.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("El documento " + etiqueta + " debe ser numérico (valor recibido: '" + valor + "').");
+        }
+    }
+
+    private Date obtenerFecha(Cell cell) {
+        if (cell == null) {
+            throw new IllegalArgumentException("La fecha es obligatoria.");
+        }
+
+        if (cell.getCellType() == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell)) {
+            return new Date(cell.getDateCellValue().getTime());
+        }
+
+        String valor = obtenerString(cell);
+        if (valor == null || valor.isEmpty()) {
+            throw new IllegalArgumentException("La fecha es obligatoria.");
+        }
+
+        try {
+            LocalDate localDate = LocalDate.parse(valor.trim());
+            return Date.valueOf(localDate);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Formato de fecha inválido ('" + valor + "'). Usa AAAA-MM-DD.");
+        }
+    }
+
+    private String normalizarEstado(String valor) {
+        if (valor == null || valor.trim().isEmpty()) {
+            throw new IllegalArgumentException("El estado es obligatorio.");
+        }
+
+        String estado = valor.trim().toLowerCase();
+        switch (estado) {
+            case "presente":
+            case "p":
+                return "Presente";
+            case "ausente":
+            case "a":
+                return "Ausente";
+            case "justificado":
+            case "j":
+                return "Justificado";
+            default:
+                throw new IllegalArgumentException("Estado inválido ('" + valor + "'). Usa Presente, Ausente o Justificado.");
+        }
+    }
+
+    private String obtenerString(Cell cell) {
+        if (cell == null) {
+            return null;
+        }
+        if (dataFormatter == null) {
+            dataFormatter = new DataFormatter();
+        }
+        String valor = dataFormatter.formatCellValue(cell);
+        return valor != null ? valor.trim() : null;
+    }
+
+    private boolean esFilaVacia(Row row) {
+        if (row == null) {
+            return true;
+        }
+        for (int c = 0; c <= 3; c++) {
+            Cell cell = row.getCell(c);
+            if (cell != null && cell.getCellType() != CellType.BLANK) {
+                String valor = obtenerString(cell);
+                if (valor != null && !valor.isEmpty()) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     // ==========================
@@ -63,4 +307,10 @@ public class AsistenciaBean implements Serializable {
     // Getters y setters
     public Asistencia getAsistencia() { return asistencia; }
     public void setAsistencia(Asistencia asistencia) { this.asistencia = asistencia; }
+
+    public Part getArchivoExcel() { return archivoExcel; }
+    public void setArchivoExcel(Part archivoExcel) { this.archivoExcel = archivoExcel; }
+
+    public SessionBean getSessionBean() { return sessionBean; }
+    public void setSessionBean(SessionBean sessionBean) { this.sessionBean = sessionBean; }
 }

--- a/src/java/dao/HogarComunitarioDAO.java
+++ b/src/java/dao/HogarComunitarioDAO.java
@@ -111,6 +111,24 @@ public class HogarComunitarioDAO {
         }
     }
 
+    public HogarComunitario buscarPorMadre(int madreId) {
+        String sql = "SELECT * FROM hogares_comunitarios WHERE madre_id = ?";
+
+        try (Connection con = ConDB.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+
+            ps.setInt(1, madreId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return mapearHogar(rs);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
     // Método privado para mapear resultset
     private HogarComunitario mapearHogar(ResultSet rs) throws Exception {
         HogarComunitario h = new HogarComunitario();

--- a/src/java/dao/NinoDAO.java
+++ b/src/java/dao/NinoDAO.java
@@ -90,6 +90,28 @@ public class NinoDAO {
         return lista;
     }
 
+    // Listar niños según la madre comunitaria
+    public List<Nino> listarPorMadre(int idMadre) {
+        List<Nino> lista = new ArrayList<>();
+        String sql = "SELECT n.* FROM ninos n " +
+                     "JOIN hogares_comunitarios h ON n.hogar_id = h.id_hogar " +
+                     "WHERE h.madre_id = ?";
+
+        try (Connection con = ConDB.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+
+            ps.setInt(1, idMadre);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    lista.add(mapearNino(rs));
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, "Error al listar niños por madre", e);
+        }
+        return lista;
+    }
+
     // Buscar niño por ID
     public Nino buscarNinoPorId(int idNino) {
         String sql = "SELECT * FROM ninos WHERE id_nino = ?";
@@ -105,6 +127,24 @@ public class NinoDAO {
             }
         } catch (SQLException e) {
             LOGGER.log(Level.SEVERE, "Error al buscar niño por ID", e);
+        }
+        return null;
+    }
+
+    public Nino buscarPorDocumento(long documento) {
+        String sql = "SELECT * FROM ninos WHERE documento = ?";
+
+        try (Connection con = ConDB.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+
+            ps.setLong(1, documento);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return mapearNino(rs);
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, "Error al buscar niño por documento", e);
         }
         return null;
     }

--- a/src/java/modelo/Asistencia.java
+++ b/src/java/modelo/Asistencia.java
@@ -7,11 +7,15 @@ public class Asistencia {
     private int idNino;
     private Date fecha;
     private String estado;
-    
+
     private String nombres;
     private String apellidos;
-    
-    private Nino nino; //aqui para intentar relacionar al niño 
+
+    private String madreNombres;
+    private String madreApellidos;
+    private String nombreHogar;
+
+    private Nino nino; //aqui para intentar relacionar al niño
 
     // Getters y Setters
     public int getIdAsistencia() {
@@ -49,4 +53,27 @@ public class Asistencia {
 
     public String getApellidos() { return apellidos; }
     public void setApellidos(String apellidos) { this.apellidos = apellidos; }
+
+    public String getMadreNombres() { return madreNombres; }
+    public void setMadreNombres(String madreNombres) { this.madreNombres = madreNombres; }
+
+    public String getMadreApellidos() { return madreApellidos; }
+    public void setMadreApellidos(String madreApellidos) { this.madreApellidos = madreApellidos; }
+
+    public String getNombreHogar() { return nombreHogar; }
+    public void setNombreHogar(String nombreHogar) { this.nombreHogar = nombreHogar; }
+
+    public String getMadreNombreCompleto() {
+        String nombresMadre = madreNombres == null ? "" : madreNombres.trim();
+        String apellidosMadre = madreApellidos == null ? "" : madreApellidos.trim();
+        String nombreCompleto = (nombresMadre + " " + apellidosMadre).trim();
+        return nombreCompleto.isEmpty() ? null : nombreCompleto;
+    }
+
+    public String getNinoNombreCompleto() {
+        String nombresNino = nombres == null ? "" : nombres.trim();
+        String apellidosNino = apellidos == null ? "" : apellidos.trim();
+        String nombreCompleto = (nombresNino + " " + apellidosNino).trim();
+        return nombreCompleto.isEmpty() ? null : nombreCompleto;
+    }
 }

--- a/web/listarAsistencia.xhtml
+++ b/web/listarAsistencia.xhtml
@@ -169,6 +169,8 @@
     <div class="main-title">ICBF CONECTA || listado de Asistencias</div>
 
     <div class="card">
+        <h:messages globalOnly="true" style="display:block;margin-bottom:15px;color:#7a3eb1;font-weight:bold;" />
+
         <h:form>
             <h:dataTable value="#{asistenciaBean.lista}" var="a" border="1">
 
@@ -178,18 +180,25 @@
                 </h:column>
 
                 <h:column>
-                    <f:facet name="header">Nombre</f:facet>
-                    #{a.nombres}
+                    <f:facet name="header">Niño</f:facet>
+                    <h:outputText value="#{a.ninoNombreCompleto != null ? a.ninoNombreCompleto : (a.nombres != null ? a.nombres.concat(' ').concat(a.apellidos) : '')}" />
                 </h:column>
 
                 <h:column>
-                    <f:facet name="header">Apellido</f:facet>
-                    #{a.apellidos}
+                    <f:facet name="header">Madre comunitaria</f:facet>
+                    <h:outputText value="#{a.madreNombreCompleto}" />
+                </h:column>
+
+                <h:column>
+                    <f:facet name="header">Hogar</f:facet>
+                    <h:outputText value="#{a.nombreHogar}" />
                 </h:column>
 
                 <h:column>
                     <f:facet name="header">Fecha</f:facet>
-                    #{a.fecha}
+                    <h:outputText value="#{a.fecha}">
+                        <f:convertDateTime pattern="yyyy-MM-dd" />
+                    </h:outputText>
                 </h:column>
 
                 <h:column>

--- a/web/registrarAsistencia.xhtml
+++ b/web/registrarAsistencia.xhtml
@@ -70,6 +70,28 @@
             box-shadow: 0px 4px 12px rgba(0,0,0,0.08);
         }
 
+        .excel-section {
+            margin-top: 35px;
+            padding: 20px;
+            border-radius: 10px;
+            background-color: rgba(243, 193, 229, 0.3);
+        }
+
+        .excel-section h3 {
+            color: #7a3eb1;
+            margin-top: 0;
+        }
+
+        .excel-section p {
+            color: #5e3370;
+            font-size: 14px;
+            margin-bottom: 15px;
+        }
+
+        .excel-section input[type="file"] {
+            margin-bottom: 15px;
+        }
+
         .form-container label {
             font-weight: bold;
             color: #7a3eb1;
@@ -145,11 +167,13 @@
         <div class="header-title">Registrar Nueva Asistencia</div>
 
     <div class="form-container">
+        <h:messages globalOnly="true" style="display:block;margin-bottom:15px;color:#7a3eb1;font-weight:bold;" />
+
         <h:form>
             <!-- Selección del niño -->
             <h:outputLabel for="nino" value="Niño:" />
             <h:selectOneMenu id="nino" value="#{asistenciaBean.asistencia.idNino}">
-                <f:selectItems value="#{asistenciaBean.ninos}" 
+                <f:selectItems value="#{asistenciaBean.ninos}"
                                var="n"
                                itemValue="#{n.idNino}" 
                                itemLabel="#{n.nombres} #{n.apellidos}" />
@@ -160,6 +184,7 @@
             <h:selectOneMenu id="estado" value="#{asistenciaBean.asistencia.estado}">
                 <f:selectItem itemValue="Presente" itemLabel="Presente" />
                 <f:selectItem itemValue="Ausente" itemLabel="Ausente" />
+                <f:selectItem itemValue="Justificado" itemLabel="Justificado" />
             </h:selectOneMenu>
 
             <div class="button-group">
@@ -167,6 +192,22 @@
                 <h:link value="Volver a la lista" outcome="listarAsistencia"/>
             </div>
         </h:form>
+
+        <div class="excel-section">
+            <h3>Importar asistencias desde Excel</h3>
+            <p>
+                Orden de columnas en el archivo: <strong>Documento de la madre</strong>,
+                <strong>Documento del niño</strong>, <strong>Fecha</strong> (AAAA-MM-DD) y
+                <strong>Estado</strong> (Presente / Ausente / Justificado).
+            </p>
+            <h:form enctype="multipart/form-data">
+                <h:inputFile id="archivoExcel" value="#{asistenciaBean.archivoExcel}" required="true"
+                             requiredMessage="Selecciona un archivo de Excel" />
+                <div class="button-group">
+                    <h:commandButton value="Cargar archivo" action="#{asistenciaBean.cargarDesdeExcel}" />
+                </div>
+            </h:form>
+        </div>
     </div>
 </h:body>
 </html>


### PR DESCRIPTION
## Summary
- agregar soporte en el bean de asistencia para filtrar los listados por madre comunitaria y cargar registros desde archivos de Excel
- enriquecer el modelo y DAO de asistencia junto con los DAO de niño y hogar para incluir datos de madre/hogar y nuevas consultas
- actualizar las vistas de registro y listado de asistencia para soportar la importación desde Excel, mostrar nuevas columnas y permitir el estado "Justificado"

## Testing
- ⚠️ `ant -f build.xml compile` *(la herramienta ant no está instalada en el entorno de ejecución)*

------
https://chatgpt.com/codex/tasks/task_b_68d1f0de73048332be965f2a3148ee76