### PR TITLE
Filtrar matrículas por madre y mejorar vistas de matrícula y reportes

### DIFF
--- a/src/java/dao/NinoDAO.java
+++ b/src/java/dao/NinoDAO.java
@@ -228,23 +228,19 @@ public class NinoDAO {
     }
     
     public List<Nino> listar() {
-    List<Nino> lista = new ArrayList<>();
-    String sql = "SELECT id_nino, nombres, apellidos FROM ninos";
+        List<Nino> lista = new ArrayList<>();
+        String sql = "SELECT * FROM ninos";
 
-    try (Connection con = ConDB.getConnection();
-         PreparedStatement ps = con.prepareStatement(sql);
-         ResultSet rs = ps.executeQuery()) {
+        try (Connection con = ConDB.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
 
-        while (rs.next()) {
-            Nino n = new Nino();
-            n.setIdNino(rs.getInt("id_nino"));
-            n.setNombres(rs.getString("nombres"));
-            n.setApellidos(rs.getString("apellidos"));
-            lista.add(n);
+            while (rs.next()) {
+                lista.add(mapearNino(rs));
+            }
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, "Error al listar niños", e);
         }
-    } catch (SQLException e) {
-        LOGGER.log(Level.SEVERE, "Error al listar niños", e);
+        return lista;
     }
-    return lista;
-}
 }

--- a/web/ReporteDetalle.xhtml
+++ b/web/ReporteDetalle.xhtml
@@ -4,126 +4,351 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:p="http://primefaces.org/ui">
+<f:view>
+    <f:metadata>
+        <f:viewAction action="#{sessionBean.verificarAcceso('madre_comunitaria')}" />
+    </f:metadata>
 
-<h:head>
-    <title>Detalle del Reporte</title>
-</h:head>
+    <h:head>
+        <title>Detalle del Reporte</title>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+        <style>
+            * {
+                box-sizing: border-box;
+            }
 
-<h:body>
-    <h:form id="formDetalle">
+            body {
+                margin: 0;
+                font-family: 'Roboto', sans-serif;
+                background-image: url("#{resource['img/fondito.png']}");
+                background-size: cover;
+                background-position: center;
+                background-repeat: no-repeat;
+                background-attachment: fixed;
+                color: #4a2d73;
+            }
 
-        <h2>Ficha del Niño</h2>
+            header {
+                background-color: rgba(255, 255, 255, 0.85);
+                padding: 15px 30px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                border-bottom: 2px solid #e5d5f5;
+                backdrop-filter: blur(4px);
+                flex-wrap: wrap;
+            }
 
-        <h:panelGrid columns="2" columnClasses="label,value" cellpadding="5">
+            header img {
+                height: 60px;
+            }
 
-            <!-- Datos del niño -->
-            <h:outputLabel value="Nombres:" />
-            <h:outputText value="#{reporteBean.seleccionado.ninoNombres} #{reporteBean.seleccionado.ninoApellidos}" />
+            nav ul {
+                list-style: none;
+                display: flex;
+                gap: 20px;
+                padding: 0;
+                margin: 0;
+                flex-wrap: wrap;
+            }
 
-            <h:outputLabel value="Documento:" />
-            <h:outputText value="#{reporteBean.seleccionado.ninoDocumento}" />
+            nav ul li a {
+                text-decoration: none;
+                color: #9B59B6;
+                font-weight: bold;
+                font-size: 16px;
+                padding: 8px 12px;
+                border-radius: 6px;
+                transition: background-color 0.3s ease;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
 
-            <h:outputLabel value="Fecha Nacimiento:" />
-            <h:outputText value="#{reporteBean.seleccionado.fechaNacimiento}">
-                <f:convertDateTime pattern="dd/MM/yyyy" />
-            </h:outputText>
+            nav ul li a:hover {
+                background-color: #f3c1e5;
+            }
 
-            <h:outputLabel value="Género:" />
-            <h:outputText value="#{reporteBean.seleccionado.genero}" />
+            .main-title {
+                text-align: center;
+                margin-top: 20px;
+                padding: 20px;
+                font-size: 26px;
+                font-weight: bold;
+                color: #7a3eb1;
+                background-color: rgba(255, 255, 255, 0.75);
+                margin: 20px auto;
+                width: 80%;
+                border-radius: 12px;
+                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+            }
 
-            <h:outputLabel value="Nacionalidad:" />
-            <h:outputText value="#{reporteBean.seleccionado.nacionalidad}" />
+            .card {
+                background-color: rgba(255, 255, 255, 0.93);
+                border-radius: 15px;
+                padding: 30px;
+                max-width: 1150px;
+                margin: 0 auto 40px;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+                border-left: 6px solid #9B59B6;
+            }
 
-            <h:outputLabel value="Fecha Ingreso:" />
-            <h:outputText value="#{reporteBean.seleccionado.fechaIngreso}">
-                <f:convertDateTime pattern="dd/MM/yyyy" />
-            </h:outputText>
+            .card h3 {
+                margin-top: 0;
+                color: #5e3370;
+                text-align: center;
+            }
 
-            <h:outputLabel value="Foto:" />
-            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.foto}" width="120" height="120" rendered="#{not empty reporteBean.seleccionado.foto}" />
-            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.foto}" />
+            .detail-grid {
+                width: 100%;
+                border-spacing: 16px 10px;
+            }
 
-            <h:outputLabel value="Carnet Vacunación:" />
-            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.carnetVacunacion}" width="120" height="120" rendered="#{not empty reporteBean.seleccionado.carnetVacunacion}" />
-            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.carnetVacunacion}" />
+            .detail-grid .label {
+                width: 35%;
+                font-weight: bold;
+                color: #5e3370;
+                text-align: right;
+                padding-right: 12px;
+            }
 
-            <h:outputLabel value="Certificado EPS:" />
-            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.certificadoEps}" width="120" height="120" rendered="#{not empty reporteBean.seleccionado.certificadoEps}" />
-            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.certificadoEps}" />
+            .detail-grid .value {
+                width: 65%;
+            }
 
-            <!-- Datos del padre -->
-            <h:outputLabel value="Padre:" />
-            <h:outputText value="#{reporteBean.seleccionado.padreNombres} #{reporteBean.seleccionado.padreApellidos}" />
+            .info-note {
+                margin-top: 15px;
+                font-style: italic;
+                font-size: 0.9em;
+                color: #6c4f89;
+                background-color: rgba(243, 225, 255, 0.6);
+                padding: 12px 16px;
+                border-radius: 10px;
+            }
 
-            <h:outputLabel value="Documento Padre:" />
-            <h:outputText value="#{reporteBean.seleccionado.padreDocumento}" />
+            .button-bar {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 15px;
+                margin-top: 25px;
+            }
 
-            <h:outputLabel value="Correo:" />
-            <h:outputText value="#{reporteBean.seleccionado.padreCorreo}" />
+            .button-bar .ui-button {
+                min-width: 190px;
+                font-weight: bold;
+            }
 
-            <h:outputLabel value="Teléfono:" />
-            <h:outputText value="#{reporteBean.seleccionado.padreTelefono}" />
+            .ui-messages {
+                margin-bottom: 20px;
+            }
 
-            <h:outputLabel value="Dirección:" />
-            <h:outputText value="#{reporteBean.seleccionado.padreDireccion}" />
+            .btn-primary {
+                background: linear-gradient(135deg, #9B59B6, #8e44ad);
+                color: #fff !important;
+                border: none;
+            }
 
-            <h:outputLabel value="Ocupación:" />
-            <h:outputText value="#{reporteBean.seleccionado.ocupacion}" />
+            .btn-primary:hover {
+                background: linear-gradient(135deg, #8e44ad, #732d91);
+            }
 
-            <h:outputLabel value="Estrato:" />
-            <h:outputText value="#{reporteBean.seleccionado.estrato}" />
+            .btn-secondary {
+                background-color: #6c757d;
+                color: #fff !important;
+                border: none;
+            }
 
-            <h:outputLabel value="Teléfono Emergencia:" />
-            <h:outputText value="#{reporteBean.seleccionado.telEmerg}" />
+            .btn-secondary:hover {
+                background-color: #5a6268;
+            }
 
-            <h:outputLabel value="Nombre Contacto Emergencia:" />
-            <h:outputText value="#{reporteBean.seleccionado.nomEmerg}" />
+            .btn-info {
+                background-color: #5dade2;
+                color: #fff !important;
+                border: none;
+            }
 
-            <h:outputLabel value="Situación Económica:" />
-            <h:outputText value="#{reporteBean.seleccionado.situacionEcon}" />
+            .btn-info:hover {
+                background-color: #3498db;
+            }
 
-            <h:outputLabel value="Documento identidad padre:" />
-            <h:panelGroup>
-                <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.documentoPadreImg}"
-                                width="120" height="120" rendered="#{not empty reporteBean.seleccionado.documentoPadreImg}" />
-                <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.documentoPadreImg}" />
-            </h:panelGroup>
+            .btn-danger {
+                background-color: #e74c3c;
+                color: #fff !important;
+                border: none;
+            }
 
-            <h:outputLabel value="ID interno usuario:" />
-            <h:outputText value="#{reporteBean.seleccionado.padreUsuarioId eq 0 ? '-' : reporteBean.seleccionado.padreUsuarioId}" />
+            .btn-danger:hover {
+                background-color: #c0392b;
+            }
+        </style>
+    </h:head>
 
-            <h:outputLabel value="Contraseña registrada:" />
-            <h:outputText value="#{empty reporteBean.seleccionado.padrePasswordHash ? '-' : reporteBean.seleccionado.padrePasswordHash}" />
+    <h:body>
+        <header>
+            <h:graphicImage library="img" name="logoSinFondo.png" alt="ICBF Conecta" />
+            <nav>
+                <ul>
+                    <li><h:link outcome="madreDashboard" value="Inicio"><i class="fas fa-home"></i></h:link></li>
+                    <li><h:link outcome="listarNinos" value=" Matrículas"><i class="fas fa-user-graduate"></i></h:link></li>
+                    <li><h:link outcome="planeaciones" value=" Planeaciones"><i class="fas fa-book"></i></h:link></li>
+                    <li><h:link outcome="desarrollo" value=" Desarrollo"><i class="fas fa-child"></i></h:link></li>
+                    <li><h:link outcome="correos" value=" Enviar Correos"><i class="fas fa-envelope"></i></h:link></li>
+                    <li>
+                        <h:form>
+                            <h:commandLink action="#{loginBean.logout}">
+                                <i class="fas fa-sign-out-alt"></i> Cerrar sesión
+                            </h:commandLink>
+                        </h:form>
+                    </li>
+                </ul>
+            </nav>
+        </header>
 
-            <!-- Datos del hogar -->
-            <h:outputLabel value="Hogar Comunitario:" />
-            <h:outputText value="#{reporteBean.seleccionado.nombreHogar}" />
+        <div class="main-title">
+            ICBF CONECTA || Detalle del reporte
+        </div>
 
-            <h:outputLabel value="Dirección Hogar:" />
-            <h:outputText value="#{reporteBean.seleccionado.hogarDireccion}" />
+        <div class="card">
+            <h:form id="formDetalle">
+                <p:messages showDetail="true" showSummary="false" closable="true" />
 
-            <h:outputLabel value="Localidad:" />
-            <h:outputText value="#{reporteBean.seleccionado.localidad}" />
+                <h:panelGroup rendered="#{not empty reporteBean.seleccionado}">
+                    <h3>Ficha completa del niño</h3>
+                    <h:panelGrid columns="2" columnClasses="label,value" styleClass="detail-grid">
+                        <h:outputLabel value="Nombres:" />
+                        <h:outputText value="#{reporteBean.seleccionado.ninoNombres} #{reporteBean.seleccionado.ninoApellidos}" />
 
-        </h:panelGrid>
+                        <h:outputLabel value="Documento:" />
+                        <h:outputText value="#{reporteBean.seleccionado.ninoDocumento}" />
 
-        <h:panelGroup layout="block" style="margin-top:10px;font-style:italic;font-size:0.9em;">
-            <h:outputText value="Nota: la contraseña se almacena cifrada. Entregue manualmente al acudiente la clave en texto plano definida durante la matrícula." />
-        </h:panelGroup>
+                        <h:outputLabel value="Fecha Nacimiento:" />
+                        <h:outputText value="#{reporteBean.seleccionado.fechaNacimiento}">
+                            <f:convertDateTime pattern="dd/MM/yyyy" />
+                        </h:outputText>
 
-        <br/>
+                        <h:outputLabel value="Género:" />
+                        <h:outputText value="#{reporteBean.seleccionado.genero}" />
 
-        <!-- Botones -->
-        <p:commandButton value="Descargar PDF"
-                         type="button"
-                         onclick="window.open('#{facesContext.externalContext.requestContextPath}/ReporteNinoPdfServlet?id=#{reporteBean.seleccionado.idNino}', '_blank');"
-                         icon="pi pi-file-pdf"
-                         styleClass="ui-button-danger"/>
+                        <h:outputLabel value="Nacionalidad:" />
+                        <h:outputText value="#{reporteBean.seleccionado.nacionalidad}" />
 
-        <p:commandButton value="Volver"
-                         action="ReporteListado?faces-redirect=true"
-                         ajax="false"
-                         icon="pi pi-arrow-left"/>
-    </h:form>
-</h:body>
+                        <h:outputLabel value="Fecha Ingreso:" />
+                        <h:outputText value="#{reporteBean.seleccionado.fechaIngreso}">
+                            <f:convertDateTime pattern="dd/MM/yyyy" />
+                        </h:outputText>
+
+                        <h:outputLabel value="Foto:" />
+                        <h:panelGroup>
+                            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.foto}"
+                                            width="120" height="120" rendered="#{not empty reporteBean.seleccionado.foto}" />
+                            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.foto}" />
+                        </h:panelGroup>
+
+                        <h:outputLabel value="Carnet Vacunación:" />
+                        <h:panelGroup>
+                            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.carnetVacunacion}"
+                                            width="120" height="120" rendered="#{not empty reporteBean.seleccionado.carnetVacunacion}" />
+                            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.carnetVacunacion}" />
+                        </h:panelGroup>
+
+                        <h:outputLabel value="Certificado EPS:" />
+                        <h:panelGroup>
+                            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.certificadoEps}"
+                                            width="120" height="120" rendered="#{not empty reporteBean.seleccionado.certificadoEps}" />
+                            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.certificadoEps}" />
+                        </h:panelGroup>
+
+                        <h:outputLabel value="Padre:" />
+                        <h:outputText value="#{reporteBean.seleccionado.padreNombres} #{reporteBean.seleccionado.padreApellidos}" />
+
+                        <h:outputLabel value="Documento Padre:" />
+                        <h:outputText value="#{reporteBean.seleccionado.padreDocumento}" />
+
+                        <h:outputLabel value="Correo:" />
+                        <h:outputText value="#{reporteBean.seleccionado.padreCorreo}" />
+
+                        <h:outputLabel value="Teléfono:" />
+                        <h:outputText value="#{reporteBean.seleccionado.padreTelefono}" />
+
+                        <h:outputLabel value="Dirección:" />
+                        <h:outputText value="#{reporteBean.seleccionado.padreDireccion}" />
+
+                        <h:outputLabel value="Ocupación:" />
+                        <h:outputText value="#{reporteBean.seleccionado.ocupacion}" />
+
+                        <h:outputLabel value="Estrato:" />
+                        <h:outputText value="#{reporteBean.seleccionado.estrato}" />
+
+                        <h:outputLabel value="Teléfono Emergencia:" />
+                        <h:outputText value="#{reporteBean.seleccionado.telEmerg}" />
+
+                        <h:outputLabel value="Nombre Contacto Emergencia:" />
+                        <h:outputText value="#{reporteBean.seleccionado.nomEmerg}" />
+
+                        <h:outputLabel value="Situación Económica:" />
+                        <h:outputText value="#{reporteBean.seleccionado.situacionEcon}" />
+
+                        <h:outputLabel value="Documento identidad padre:" />
+                        <h:panelGroup>
+                            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{reporteBean.seleccionado.documentoPadreImg}"
+                                            width="120" height="120" rendered="#{not empty reporteBean.seleccionado.documentoPadreImg}" />
+                            <h:outputText value="No disponible" rendered="#{empty reporteBean.seleccionado.documentoPadreImg}" />
+                        </h:panelGroup>
+
+                        <h:outputLabel value="ID interno usuario:" />
+                        <h:outputText value="#{reporteBean.seleccionado.padreUsuarioId eq 0 ? '-' : reporteBean.seleccionado.padreUsuarioId}" />
+
+                        <h:outputLabel value="Contraseña registrada:" />
+                        <h:outputText value="#{empty reporteBean.seleccionado.padrePasswordHash ? '-' : reporteBean.seleccionado.padrePasswordHash}" />
+
+                        <h:outputLabel value="Hogar Comunitario:" />
+                        <h:outputText value="#{reporteBean.seleccionado.nombreHogar}" />
+
+                        <h:outputLabel value="Dirección Hogar:" />
+                        <h:outputText value="#{reporteBean.seleccionado.hogarDireccion}" />
+
+                        <h:outputLabel value="Localidad:" />
+                        <h:outputText value="#{reporteBean.seleccionado.localidad}" />
+                    </h:panelGrid>
+
+                    <div class="info-note">
+                        Nota: la contraseña se almacena cifrada. Entregue manualmente al acudiente la clave en texto plano definida durante la matrícula.
+                    </div>
+
+                    <div class="button-bar">
+                        <p:commandButton value="Descargar PDF" icon="pi pi-file-pdf"
+                                         type="button"
+                                         onclick="window.open('#{facesContext.externalContext.requestContextPath}/ReporteNinoPdfServlet?id=#{reporteBean.seleccionado.idNino}', '_blank');"
+                                         styleClass="btn-danger" />
+
+                        <p:commandButton value="Volver al listado" icon="pi pi-arrow-left"
+                                         action="ReporteListado?faces-redirect=true"
+                                         ajax="false"
+                                         styleClass="btn-secondary" />
+
+                        <p:commandButton value="Ir a matrículas" icon="pi pi-users"
+                                         action="listarNinos?faces-redirect=true"
+                                         ajax="false"
+                                         styleClass="btn-info" />
+                    </div>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{empty reporteBean.seleccionado}" layout="block">
+                    <div class="info-note">
+                        No se encontró información para el reporte solicitado.
+                    </div>
+                    <div class="button-bar">
+                        <p:commandButton value="Volver al listado" icon="pi pi-arrow-left"
+                                         action="ReporteListado?faces-redirect=true"
+                                         ajax="false"
+                                         styleClass="btn-secondary" />
+                    </div>
+                </h:panelGroup>
+            </h:form>
+        </div>
+    </h:body>
+</f:view>
 </html>

--- a/web/ReporteListado.xhtml
+++ b/web/ReporteListado.xhtml
@@ -4,47 +4,256 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:p="http://primefaces.org/ui">
+<f:view>
+    <f:metadata>
+        <f:viewAction action="#{sessionBean.verificarAcceso('madre_comunitaria')}" />
+    </f:metadata>
 
-<h:head>
-    <title>Listado de Reportes</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-</h:head>
+    <h:head>
+        <title>Listado de Reportes</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+        <style>
+            * {
+                box-sizing: border-box;
+            }
 
-<h:body>
-    <h:form id="formReportes">
+            body {
+                margin: 0;
+                font-family: 'Roboto', sans-serif;
+                background-image: url("#{resource['img/fondito.png']}");
+                background-size: cover;
+                background-position: center;
+                background-repeat: no-repeat;
+                background-attachment: fixed;
+                color: #4a2d73;
+            }
 
-        <h2>Reportes de Niños</h2>
+            header {
+                background-color: rgba(255, 255, 255, 0.85);
+                padding: 15px 30px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                border-bottom: 2px solid #e5d5f5;
+                backdrop-filter: blur(4px);
+                flex-wrap: wrap;
+            }
 
-        <p:dataTable value="#{reporteBean.listaReportes}" var="r" paginator="true" rows="10" 
-                     emptyMessage="No hay reportes disponibles">
+            header img {
+                height: 60px;
+            }
 
-            <p:column headerText="Niño">
-                <h:outputText value="#{r.ninoNombres} #{r.ninoApellidos}" />
-            </p:column>
+            nav ul {
+                list-style: none;
+                display: flex;
+                gap: 20px;
+                padding: 0;
+                margin: 0;
+                flex-wrap: wrap;
+            }
 
-            <p:column headerText="Documento">
-                <h:outputText value="#{r.ninoDocumento}" />
-            </p:column>
+            nav ul li a {
+                text-decoration: none;
+                color: #9B59B6;
+                font-weight: bold;
+                font-size: 16px;
+                padding: 8px 12px;
+                border-radius: 6px;
+                transition: background-color 0.3s ease;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
 
-            <p:column headerText="Padre">
-                <h:outputText value="#{r.padreNombres} #{r.padreApellidos}" />
-            </p:column>
+            nav ul li a:hover {
+                background-color: #f3c1e5;
+            }
 
-            <p:column headerText="Acciones">
-                <p:commandButton value="Ver Detalle"
-                                 action="#{reporteBean.verDetalle(r.idNino)}"
-                                 ajax="false"/>
-            </p:column>
+            .main-title {
+                text-align: center;
+                margin-top: 20px;
+                padding: 20px;
+                font-size: 26px;
+                font-weight: bold;
+                color: #7a3eb1;
+                background-color: rgba(255, 255, 255, 0.75);
+                margin: 20px auto;
+                width: 80%;
+                border-radius: 12px;
+                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+            }
 
-            <p:column headerText="Reporte PDF" styleClass="acciones-columna">
-                <h:outputLink value="#{facesContext.externalContext.requestContextPath}/ReporteNinoPdfServlet?id=#{r.idNino}" target="_blank">
-                    <i class="pi pi-file-pdf" style="margin-right:4px"></i>
-                    <h:outputText value="Descargar" />
-                </h:outputLink>
-            </p:column>
+            .card {
+                background-color: rgba(255, 255, 255, 0.93);
+                border-radius: 15px;
+                padding: 30px;
+                max-width: 1150px;
+                margin: 0 auto 40px;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+                border-left: 6px solid #9B59B6;
+            }
 
-        </p:dataTable>
+            .card h3 {
+                margin: 0 0 15px;
+                font-size: 22px;
+                color: #5e3370;
+                text-align: center;
+            }
 
-    </h:form>
-</h:body>
+            .ui-datatable thead th {
+                background: #f3c1e5;
+                color: #5e3370;
+                text-align: center;
+            }
+
+            .ui-datatable tbody td {
+                text-align: center;
+                color: #4a2d73;
+            }
+
+            .action-buttons {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 15px;
+                margin-top: 25px;
+            }
+
+            .action-buttons .ui-button {
+                min-width: 200px;
+                font-weight: bold;
+            }
+
+            .btn-primary {
+                background: linear-gradient(135deg, #9B59B6, #8e44ad);
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-primary:hover {
+                background: linear-gradient(135deg, #8e44ad, #732d91);
+            }
+
+            .btn-secondary {
+                background-color: #6c757d;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-secondary:hover {
+                background-color: #5a6268;
+            }
+
+            .btn-info {
+                background-color: #5dade2;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-info:hover {
+                background-color: #3498db;
+            }
+
+            .pdf-link {
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                color: #d35400;
+                font-weight: bold;
+                text-decoration: none;
+            }
+
+            .pdf-link:hover {
+                text-decoration: underline;
+            }
+
+            .ui-messages {
+                margin-bottom: 20px;
+            }
+        </style>
+    </h:head>
+
+    <h:body>
+        <header>
+            <h:graphicImage library="img" name="logoSinFondo.png" alt="ICBF Conecta" />
+            <nav>
+                <ul>
+                    <li><h:link outcome="madreDashboard" value="Inicio"><i class="fas fa-home"></i></h:link></li>
+                    <li><h:link outcome="listarNinos" value=" Matrículas"><i class="fas fa-user-graduate"></i></h:link></li>
+                    <li><h:link outcome="planeaciones" value=" Planeaciones"><i class="fas fa-book"></i></h:link></li>
+                    <li><h:link outcome="desarrollo" value=" Desarrollo"><i class="fas fa-child"></i></h:link></li>
+                    <li><h:link outcome="correos" value=" Enviar Correos"><i class="fas fa-envelope"></i></h:link></li>
+                    <li>
+                        <h:form>
+                            <h:commandLink action="#{loginBean.logout}">
+                                <i class="fas fa-sign-out-alt"></i> Cerrar sesión
+                            </h:commandLink>
+                        </h:form>
+                    </li>
+                </ul>
+            </nav>
+        </header>
+
+        <div class="main-title">
+            ICBF CONECTA || Reportes de niños matriculados
+        </div>
+
+        <div class="card">
+            <h3>Listado de reportes generados</h3>
+            <h:form id="formReportes">
+                <p:messages showDetail="true" showSummary="false" closable="true" />
+
+                <p:dataTable value="#{reporteBean.listaReportes}" var="r" paginator="true" rows="10"
+                             reflow="true"
+                             emptyMessage="No hay reportes disponibles">
+
+                    <p:column headerText="Niño">
+                        <h:outputText value="#{r.ninoNombres} #{r.ninoApellidos}" />
+                    </p:column>
+
+                    <p:column headerText="Documento">
+                        <h:outputText value="#{r.ninoDocumento}" />
+                    </p:column>
+
+                    <p:column headerText="Padre">
+                        <h:outputText value="#{r.padreNombres} #{r.padreApellidos}" />
+                    </p:column>
+
+                    <p:column headerText="Hogar">
+                        <h:outputText value="#{r.nombreHogar}" />
+                    </p:column>
+
+                    <p:column headerText="Acciones" style="text-align:center; width:160px;">
+                        <p:commandButton value="Ver detalle"
+                                         icon="pi pi-search"
+                                         action="#{reporteBean.verDetalle(r.idNino)}"
+                                         ajax="false"
+                                         styleClass="btn-primary" />
+                    </p:column>
+
+                    <p:column headerText="Reporte PDF" style="text-align:center;">
+                        <h:outputLink value="#{facesContext.externalContext.requestContextPath}/ReporteNinoPdfServlet?id=#{r.idNino}" target="_blank" styleClass="pdf-link">
+                            <i class="pi pi-file-pdf"></i>
+                            <h:outputText value="Descargar" />
+                        </h:outputLink>
+                    </p:column>
+                </p:dataTable>
+
+                <div class="action-buttons">
+                    <p:commandButton value="Volver a matrículas" icon="pi pi-arrow-left"
+                                     action="listarNinos?faces-redirect=true"
+                                     ajax="false"
+                                     styleClass="btn-secondary" />
+
+                    <p:commandButton value="Volver al panel" icon="pi pi-home"
+                                     action="madreDashboard?faces-redirect=true"
+                                     ajax="false"
+                                     styleClass="btn-info" />
+                </div>
+            </h:form>
+        </div>
+    </h:body>
+</f:view>
 </html>

--- a/web/crearNino.xhtml
+++ b/web/crearNino.xhtml
@@ -3,129 +3,394 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
-<h:head>
-    <title>Matrícula de Niño</title>
-</h:head>
-<h:body>
+<f:view>
+    <f:metadata>
+        <f:viewAction action="#{sessionBean.verificarAcceso('madre_comunitaria')}" />
+    </f:metadata>
 
-<h:form enctype="multipart/form-data">
-    <h:messages globalOnly="true" style="color:red;" />
+    <h:head>
+        <title>Matrícula de Niño</title>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+        <style>
+            * {
+                box-sizing: border-box;
+            }
 
-    <h2>Datos del Padre Registrado</h2>
-    <h:panelGroup rendered="#{ninoBean.padreDisponible}">
-        <h:panelGrid columns="2" columnClasses="label,value" styleClass="resumen-padre">
-            <h:outputLabel value="ID Padre:" />
-            <h:outputText value="#{ninoBean.padreIdSeleccionado}" />
+            body {
+                margin: 0;
+                font-family: 'Roboto', sans-serif;
+                background-image: url("#{resource['img/fondito.png']}");
+                background-size: cover;
+                background-position: center;
+                background-repeat: no-repeat;
+                background-attachment: fixed;
+                color: #4a2d73;
+            }
 
-            <h:outputLabel value="Nombres:" />
-            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.nombres} #{ninoBean.usuarioPadreSeleccionado.apellidos}" />
+            header {
+                background-color: rgba(255, 255, 255, 0.85);
+                padding: 15px 30px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                border-bottom: 2px solid #e5d5f5;
+                backdrop-filter: blur(4px);
+                flex-wrap: wrap;
+            }
 
-            <h:outputLabel value="Documento:" />
-            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.documento}" />
+            header img {
+                height: 60px;
+            }
 
-            <h:outputLabel value="Correo:" />
-            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.correo}" />
+            nav ul {
+                list-style: none;
+                display: flex;
+                gap: 20px;
+                padding: 0;
+                margin: 0;
+                flex-wrap: wrap;
+            }
 
-            <h:outputLabel value="Teléfono:" />
-            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.telefono}" />
+            nav ul li a {
+                text-decoration: none;
+                color: #9B59B6;
+                font-weight: bold;
+                font-size: 16px;
+                padding: 8px 12px;
+                border-radius: 6px;
+                transition: background-color 0.3s ease;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
 
-            <h:outputLabel value="Dirección:" />
-            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.direccion}" />
+            nav ul li a:hover {
+                background-color: #f3c1e5;
+            }
 
-            <h:outputLabel value="Ocupación:" />
-            <h:outputText value="#{ninoBean.padreSeleccionado.ocupacion}" />
+            .main-title {
+                text-align: center;
+                margin-top: 20px;
+                padding: 20px;
+                font-size: 26px;
+                font-weight: bold;
+                color: #7a3eb1;
+                background-color: rgba(255, 255, 255, 0.75);
+                margin: 20px auto;
+                width: 80%;
+                border-radius: 12px;
+                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+            }
 
-            <h:outputLabel value="Estrato:" />
-            <h:outputText value="#{ninoBean.padreSeleccionado.estrato}" />
+            .page-wrapper {
+                max-width: 1150px;
+                margin: 0 auto 40px;
+                display: flex;
+                flex-direction: column;
+                gap: 25px;
+            }
 
-            <h:outputLabel value="Contacto emergencia:" />
-            <h:outputText value="#{ninoBean.padreSeleccionado.nombreContactoEmergencia} / #{ninoBean.padreSeleccionado.telefonoContactoEmergencia}" />
+            .card {
+                background-color: rgba(255, 255, 255, 0.93);
+                border-radius: 15px;
+                padding: 30px;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+                border-left: 6px solid #9B59B6;
+            }
 
-            <h:outputLabel value="Situación económica:" />
-            <h:outputText value="#{ninoBean.padreSeleccionado.situacionEconomicaHogar}" />
+            .card h3 {
+                margin: 0 0 15px;
+                font-size: 22px;
+                color: #5e3370;
+                text-align: center;
+            }
 
-            <h:outputLabel value="Documento identidad:" />
-            <h:panelGroup>
-                <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{ninoBean.padreSeleccionado.documentoIdentidadImg}"
-                                width="120" height="120" rendered="#{not empty ninoBean.padreSeleccionado.documentoIdentidadImg}" />
-                <h:outputText value="No disponible" rendered="#{empty ninoBean.padreSeleccionado.documentoIdentidadImg}" />
-            </h:panelGroup>
-        </h:panelGrid>
-    </h:panelGroup>
-    <h:panelGroup rendered="#{!ninoBean.padreDisponible}" style="color:#c0392b; font-weight:bold;">
-        <h:outputText value="Debes registrar primero los datos del padre antes de matricular al niño." />
-        <br/>
-        <h:link outcome="crearPadre" value="Registrar datos del padre" />
-    </h:panelGroup>
+            .summary-grid {
+                width: 100%;
+                border-spacing: 16px 10px;
+            }
 
-    <h:inputHidden value="#{ninoBean.padreIdSeleccionado}" />
+            .summary-grid .label {
+                font-weight: bold;
+                color: #5e3370;
+                text-align: right;
+                padding-right: 10px;
+                width: 30%;
+            }
 
-    <p:separator/>
+            .summary-grid .value {
+                width: 70%;
+            }
 
-    <h2>Datos del Niño</h2>
-    <h:panelGrid columns="2" columnClasses="label,value">
+            .input-grid {
+                width: 100%;
+                border-spacing: 16px 12px;
+            }
 
-        <h:outputLabel for="nombresN" value="Nombres:" />
-        <h:inputText id="nombresN" value="#{ninoBean.nino.nombres}" required="true" />
+            .input-grid .label {
+                width: 30%;
+                font-weight: bold;
+                color: #5e3370;
+                text-align: right;
+                padding-right: 10px;
+            }
 
-        <h:outputLabel for="apellidosN" value="Apellidos:" />
-        <h:inputText id="apellidosN" value="#{ninoBean.nino.apellidos}" required="true" />
+            .input-grid .value {
+                width: 70%;
+            }
 
-        <h:outputLabel for="documentoN" value="Documento:" />
-        <h:inputText id="documentoN" value="#{ninoBean.nino.documento}" />
+            .input-field {
+                width: 100%;
+                padding: 10px 12px;
+                border: 1px solid #c7b4df;
+                border-radius: 8px;
+                font-size: 15px;
+                background-color: #fff;
+                transition: border-color 0.3s ease;
+            }
 
-        <h:outputLabel for="fechaNac" value="Fecha de nacimiento:" />
-        <div class="form-field">
-            <h:outputLabel for="fechaNac" value="Fecha de nacimiento" styleClass="field-label"/>
-            <p:calendar id="fechaNac"
-                        value="#{ninoBean.nino.fechaNacimiento}"
-                        pattern="yyyy-MM-dd"
-                        navigator="true"
-                        yearRange="1950:2100"
-                        required="true"
-                        requiredMessage="Selecciona la fecha de nacimiento."
-                        inputStyleClass="input-field"/>
-            <h:message for="fechaNac" styleClass="error-msg"/>
+            .input-field:focus {
+                outline: none;
+                border-color: #9B59B6;
+                box-shadow: 0 0 4px rgba(155, 89, 182, 0.4);
+            }
+
+            textarea.input-field {
+                resize: vertical;
+            }
+
+            .error-msg {
+                color: #c0392b;
+                font-size: 12px;
+                margin-top: 4px;
+                display: block;
+            }
+
+            .info-alert {
+                background-color: rgba(255, 235, 238, 0.95);
+                color: #a94442;
+                padding: 15px 20px;
+                border-radius: 10px;
+                border-left: 6px solid #d9534f;
+                font-weight: bold;
+                text-align: center;
+            }
+
+            .button-bar {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 15px;
+                margin-top: 20px;
+            }
+
+            .button-bar .ui-button {
+                min-width: 190px;
+                font-weight: bold;
+            }
+
+            .ui-messages {
+                margin-bottom: 20px;
+            }
+
+            .btn-primary {
+                background: linear-gradient(135deg, #9B59B6, #8e44ad);
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-primary:hover {
+                background: linear-gradient(135deg, #8e44ad, #732d91);
+            }
+
+            .btn-secondary {
+                background-color: #6c757d;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-secondary:hover {
+                background-color: #5a6268;
+            }
+
+            .btn-info {
+                background-color: #5dade2;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-info:hover {
+                background-color: #3498db;
+            }
+        </style>
+    </h:head>
+
+    <h:body>
+        <header>
+            <h:graphicImage library="img" name="logoSinFondo.png" alt="ICBF Conecta" />
+            <nav>
+                <ul>
+                    <li><h:link outcome="madreDashboard" value="Inicio"><i class="fas fa-home"></i></h:link></li>
+                    <li><h:link outcome="listarNinos" value=" Matrículas"><i class="fas fa-user-graduate"></i></h:link></li>
+                    <li><h:link outcome="planeaciones" value=" Planeaciones"><i class="fas fa-book"></i></h:link></li>
+                    <li><h:link outcome="desarrollo" value=" Desarrollo"><i class="fas fa-child"></i></h:link></li>
+                    <li><h:link outcome="correos" value=" Enviar Correos"><i class="fas fa-envelope"></i></h:link></li>
+                    <li>
+                        <h:form>
+                            <h:commandLink action="#{loginBean.logout}">
+                                <i class="fas fa-sign-out-alt"></i> Cerrar sesión
+                            </h:commandLink>
+                        </h:form>
+                    </li>
+                </ul>
+            </nav>
+        </header>
+
+        <div class="main-title">
+            ICBF CONECTA || Matrícula de niño
         </div>
 
-        <h:outputLabel for="genero" value="Género:" />
-        <h:selectOneMenu id="genero" value="#{ninoBean.nino.genero}">
-            <f:selectItem itemLabel="Seleccione..." itemValue="" />
-            <f:selectItem itemLabel="Masculino" itemValue="masculino" />
-            <f:selectItem itemLabel="Femenino" itemValue="femenino" />
-            <f:selectItem itemLabel="Otro" itemValue="otro" />
-            <f:selectItem itemLabel="No especificado" itemValue="no_especificado" />
-        </h:selectOneMenu>
+        <div class="page-wrapper">
+            <h:form enctype="multipart/form-data">
+                <p:messages globalOnly="true" showDetail="true" closable="true" />
 
-        <h:outputLabel for="nacionalidad" value="Nacionalidad:" />
-        <h:inputText id="nacionalidad" value="#{ninoBean.nino.nacionalidad}" />
+                <h:panelGroup rendered="#{ninoBean.padreDisponible}">
+                    <div class="card">
+                        <h3>Datos del padre registrado</h3>
+                        <h:panelGrid columns="2" columnClasses="label,value" styleClass="summary-grid">
+                            <h:outputLabel value="ID Padre:" />
+                            <h:outputText value="#{ninoBean.padreIdSeleccionado}" />
 
-        <h:outputLabel for="hogar" value="Hogar comunitario:" />
-        <h:selectOneMenu id="hogar" value="#{ninoBean.nino.hogarId}" required="true">
-            <f:selectItem itemLabel="Seleccione un hogar..." itemValue="" noSelectionOption="true"/>
-            <f:selectItems value="#{ninoBean.listaHogares}" var="h"
-                           itemValue="#{h.idHogar}"
-                           itemLabel="#{h.nombreHogar} - #{h.localidad}" />
-        </h:selectOneMenu>
+                            <h:outputLabel value="Nombres:" />
+                            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.nombres} #{ninoBean.usuarioPadreSeleccionado.apellidos}" />
 
-        <h:outputLabel for="fotoNino" value="Foto del niño:" />
-        <h:inputFile id="fotoNino" value="#{ninoBean.fotoNinoPart}" required="true" />
+                            <h:outputLabel value="Documento:" />
+                            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.documento}" />
 
-    </h:panelGrid>
+                            <h:outputLabel value="Correo:" />
+                            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.correo}" />
 
-    <p:separator/>
+                            <h:outputLabel value="Teléfono:" />
+                            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.telefono}" />
 
-    <p:commandButton value="Guardar Matrícula"
-                     action="#{ninoBean.guardarMatricula}"
-                     ajax="false"
-                     styleClass="ui-button-success"
-                     disabled="#{!ninoBean.padreDisponible}"/>
+                            <h:outputLabel value="Dirección:" />
+                            <h:outputText value="#{ninoBean.usuarioPadreSeleccionado.direccion}" />
 
-    <p:commandButton value="Cancelar" immediate="true"
-                     action="#{ninoBean.cancelar}"
-                     styleClass="ui-button-secondary"/>
+                            <h:outputLabel value="Ocupación:" />
+                            <h:outputText value="#{ninoBean.padreSeleccionado.ocupacion}" />
 
-</h:form>
+                            <h:outputLabel value="Estrato:" />
+                            <h:outputText value="#{ninoBean.padreSeleccionado.estrato}" />
 
-</h:body>
+                            <h:outputLabel value="Contacto emergencia:" />
+                            <h:outputText value="#{ninoBean.padreSeleccionado.nombreContactoEmergencia} / #{ninoBean.padreSeleccionado.telefonoContactoEmergencia}" />
+
+                            <h:outputLabel value="Situación económica:" />
+                            <h:outputText value="#{ninoBean.padreSeleccionado.situacionEconomicaHogar}" />
+
+                            <h:outputLabel value="Documento identidad:" />
+                            <h:panelGroup>
+                                <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{ninoBean.padreSeleccionado.documentoIdentidadImg}"
+                                                width="120" height="120" rendered="#{not empty ninoBean.padreSeleccionado.documentoIdentidadImg}" />
+                                <h:outputText value="No disponible" rendered="#{empty ninoBean.padreSeleccionado.documentoIdentidadImg}" />
+                            </h:panelGroup>
+                        </h:panelGrid>
+                    </div>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{!ninoBean.padreDisponible}" layout="block" styleClass="info-alert">
+                    <h:outputText value="Debes registrar primero los datos del padre antes de matricular al niño." />
+                    <br />
+                    <h:link outcome="crearPadre" value="Registrar datos del padre" />
+                </h:panelGroup>
+
+                <h:inputHidden value="#{ninoBean.padreIdSeleccionado}" />
+
+                <div class="card">
+                    <h3>Datos del niño</h3>
+                    <h:panelGrid columns="2" columnClasses="label,value" styleClass="input-grid">
+                        <h:outputLabel for="nombresN" value="Nombres:" />
+                        <h:inputText id="nombresN" value="#{ninoBean.nino.nombres}" required="true"
+                                     requiredMessage="Los nombres del niño son obligatorios."
+                                     styleClass="input-field" />
+
+                        <h:outputLabel for="apellidosN" value="Apellidos:" />
+                        <h:inputText id="apellidosN" value="#{ninoBean.nino.apellidos}" required="true"
+                                     requiredMessage="Los apellidos del niño son obligatorios."
+                                     styleClass="input-field" />
+
+                        <h:outputLabel for="documentoN" value="Documento:" />
+                        <h:inputText id="documentoN" value="#{ninoBean.nino.documento}" maxlength="15"
+                                     validatorMessage="El documento del niño solo debe contener números."
+                                     styleClass="input-field">
+                            <f:validateRegex pattern="\d*" />
+                        </h:inputText>
+                        <h:message for="documentoN" styleClass="error-msg" />
+
+                        <h:outputLabel for="fechaNac" value="Fecha de nacimiento:" />
+                        <p:calendar id="fechaNac"
+                                    value="#{ninoBean.nino.fechaNacimiento}"
+                                    pattern="yyyy-MM-dd"
+                                    navigator="true"
+                                    yearRange="1950:2100"
+                                    required="true"
+                                    requiredMessage="Selecciona la fecha de nacimiento."
+                                    inputStyleClass="input-field" />
+
+                        <h:outputLabel for="genero" value="Género:" />
+                        <h:selectOneMenu id="genero" value="#{ninoBean.nino.genero}" styleClass="input-field">
+                            <f:selectItem itemLabel="Seleccione..." itemValue="" />
+                            <f:selectItem itemLabel="Masculino" itemValue="masculino" />
+                            <f:selectItem itemLabel="Femenino" itemValue="femenino" />
+                            <f:selectItem itemLabel="Otro" itemValue="otro" />
+                            <f:selectItem itemLabel="No especificado" itemValue="no_especificado" />
+                        </h:selectOneMenu>
+
+                        <h:outputLabel for="nacionalidad" value="Nacionalidad:" />
+                        <h:inputText id="nacionalidad" value="#{ninoBean.nino.nacionalidad}" styleClass="input-field" />
+
+                        <h:outputLabel for="hogar" value="Hogar comunitario:" />
+                        <h:selectOneMenu id="hogar" value="#{ninoBean.nino.hogarId}" required="true"
+                                         requiredMessage="Selecciona el hogar comunitario."
+                                         styleClass="input-field">
+                            <f:selectItem itemLabel="Seleccione un hogar..." itemValue="" noSelectionOption="true" />
+                            <f:selectItems value="#{ninoBean.listaHogares}" var="h"
+                                           itemValue="#{h.idHogar}"
+                                           itemLabel="#{h.nombreHogar} - #{h.localidad}" />
+                        </h:selectOneMenu>
+
+                        <h:outputLabel for="fotoNino" value="Foto del niño:" />
+                        <h:inputFile id="fotoNino" value="#{ninoBean.fotoNinoPart}" required="true"
+                                     requiredMessage="Debes adjuntar la foto del niño." />
+                    </h:panelGrid>
+
+                    <h:panelGroup rendered="#{empty ninoBean.listaHogares}" layout="block" styleClass="info-alert" style="margin-top:15px;">
+                        <h:outputText value="No hay hogares activos disponibles para registrar la matrícula." />
+                    </h:panelGroup>
+
+                    <div class="button-bar">
+                        <p:commandButton value="Guardar matrícula" icon="pi pi-save"
+                                         action="#{ninoBean.guardarMatricula}"
+                                         ajax="false"
+                                         styleClass="btn-primary"
+                                         disabled="#{!ninoBean.padreDisponible or empty ninoBean.listaHogares}" />
+
+                        <p:commandButton value="Cancelar" icon="pi pi-times"
+                                         action="#{ninoBean.cancelar}"
+                                         ajax="false"
+                                         immediate="true"
+                                         styleClass="btn-secondary" />
+
+                        <p:commandButton value="Volver al listado" icon="pi pi-arrow-left"
+                                         action="listarNinos?faces-redirect=true"
+                                         ajax="false"
+                                         immediate="true"
+                                         styleClass="btn-info" />
+                    </div>
+                </div>
+            </h:form>
+        </div>
+    </h:body>
+</f:view>
 </html>

--- a/web/crearPadre.xhtml
+++ b/web/crearPadre.xhtml
@@ -3,77 +3,336 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
-<h:head>
-    <title>Registrar Padre / Acudiente</title>
-</h:head>
-<h:body>
+<f:view>
+    <f:metadata>
+        <f:viewAction action="#{sessionBean.verificarAcceso('madre_comunitaria')}" />
+    </f:metadata>
 
-<h:form enctype="multipart/form-data">
-    <p:messages showDetail="true" showSummary="false" closable="true" />
+    <h:head>
+        <title>Registrar Padre / Acudiente</title>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+        <style>
+            * {
+                box-sizing: border-box;
+            }
 
-    <h2>Datos del Usuario Padre</h2>
-    <h:panelGrid columns="2" columnClasses="label,value">
-        <h:outputLabel for="nombresP" value="Nombres:" />
-        <h:inputText id="nombresP" value="#{padreMatriculaBean.usuarioPadre.nombres}" required="true" />
+            body {
+                margin: 0;
+                font-family: 'Roboto', sans-serif;
+                background-image: url("#{resource['img/fondito.png']}");
+                background-size: cover;
+                background-position: center;
+                background-repeat: no-repeat;
+                background-attachment: fixed;
+                color: #4a2d73;
+            }
 
-        <h:outputLabel for="apellidosP" value="Apellidos:" />
-        <h:inputText id="apellidosP" value="#{padreMatriculaBean.usuarioPadre.apellidos}" required="true" />
+            header {
+                background-color: rgba(255, 255, 255, 0.85);
+                padding: 15px 30px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                border-bottom: 2px solid #e5d5f5;
+                backdrop-filter: blur(4px);
+                flex-wrap: wrap;
+            }
 
-        <h:outputLabel for="documentoP" value="Documento:" />
-        <h:inputText id="documentoP" value="#{padreMatriculaBean.usuarioPadre.documento}" required="true" />
+            header img {
+                height: 60px;
+            }
 
-        <h:outputLabel for="correoP" value="Correo electrónico:" />
-        <h:inputText id="correoP" value="#{padreMatriculaBean.usuarioPadre.correo}" required="true" />
+            nav ul {
+                list-style: none;
+                display: flex;
+                gap: 20px;
+                padding: 0;
+                margin: 0;
+                flex-wrap: wrap;
+            }
 
-        <h:outputLabel for="direccionP" value="Dirección:" />
-        <h:inputText id="direccionP" value="#{padreMatriculaBean.usuarioPadre.direccion}" />
+            nav ul li a {
+                text-decoration: none;
+                color: #9B59B6;
+                font-weight: bold;
+                font-size: 16px;
+                padding: 8px 12px;
+                border-radius: 6px;
+                transition: background-color 0.3s ease;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
 
-        <h:outputLabel for="telefonoP" value="Teléfono:" />
-        <h:inputText id="telefonoP" value="#{padreMatriculaBean.usuarioPadre.telefono}" />
+            nav ul li a:hover {
+                background-color: #f3c1e5;
+            }
 
-        <h:outputLabel for="pass1" value="Contraseña:" />
-        <h:inputSecret id="pass1" value="#{padreMatriculaBean.password1}" required="true" redisplay="true" />
+            .main-title {
+                text-align: center;
+                margin-top: 20px;
+                padding: 20px;
+                font-size: 26px;
+                font-weight: bold;
+                color: #7a3eb1;
+                background-color: rgba(255, 255, 255, 0.75);
+                margin: 20px auto;
+                width: 80%;
+                border-radius: 12px;
+                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+            }
 
-        <h:outputLabel for="pass2" value="Confirmar contraseña:" />
-        <h:inputSecret id="pass2" value="#{padreMatriculaBean.password2}" required="true" redisplay="true" />
-    </h:panelGrid>
+            .form-wrapper {
+                max-width: 1150px;
+                margin: 0 auto 40px;
+                display: flex;
+                flex-direction: column;
+                gap: 25px;
+            }
 
-    <p:separator/>
+            .form-card {
+                background-color: rgba(255, 255, 255, 0.93);
+                border-radius: 15px;
+                padding: 30px;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+                border-left: 6px solid #9B59B6;
+            }
 
-    <h2>Información Complementaria</h2>
-    <h:panelGrid columns="2" columnClasses="label,value">
-        <h:outputLabel for="ocupacion" value="Ocupación:" />
-        <h:inputText id="ocupacion" value="#{padreMatriculaBean.padre.ocupacion}" />
+            .form-card h3 {
+                margin-top: 0;
+                margin-bottom: 20px;
+                font-size: 22px;
+                text-align: center;
+                color: #5e3370;
+            }
 
-        <h:outputLabel for="estrato" value="Estrato:" />
-        <h:inputText id="estrato" value="#{padreMatriculaBean.padre.estrato}">
-            <f:convertNumber integerOnly="true" />
-        </h:inputText>
+            .input-grid {
+                width: 100%;
+                border-spacing: 16px 12px;
+            }
 
-        <h:outputLabel for="telEmerg" value="Teléfono emergencia:" />
-        <h:inputText id="telEmerg" value="#{padreMatriculaBean.padre.telefonoContactoEmergencia}" />
+            .input-grid .label {
+                width: 30%;
+                font-weight: bold;
+                color: #5e3370;
+                text-align: right;
+                padding-right: 10px;
+            }
 
-        <h:outputLabel for="nomEmerg" value="Nombre contacto emergencia:" />
-        <h:inputText id="nomEmerg" value="#{padreMatriculaBean.padre.nombreContactoEmergencia}" />
+            .input-grid .value {
+                width: 70%;
+            }
 
-        <h:outputLabel for="sitEcon" value="Situación económica hogar:" />
-        <h:inputTextarea id="sitEcon" value="#{padreMatriculaBean.padre.situacionEconomicaHogar}" rows="3" cols="30" />
+            .input-field {
+                width: 100%;
+                padding: 10px 12px;
+                border: 1px solid #c7b4df;
+                border-radius: 8px;
+                font-size: 15px;
+                background-color: #fff;
+                transition: border-color 0.3s ease;
+            }
 
-        <h:outputLabel for="docPadre" value="Documento de identidad (imagen):" />
-        <h:inputFile id="docPadre" value="#{padreMatriculaBean.documentoPart}" required="true" />
-    </h:panelGrid>
+            .input-field:focus {
+                outline: none;
+                border-color: #9B59B6;
+                box-shadow: 0 0 4px rgba(155, 89, 182, 0.4);
+            }
 
-    <p:separator/>
+            textarea.input-field {
+                resize: vertical;
+                min-height: 90px;
+            }
 
-    <p:commandButton value="Guardar y continuar"
-                     action="#{padreMatriculaBean.guardarPadre}"
-                     ajax="false"
-                     styleClass="ui-button-success" />
+            .error-msg {
+                color: #c0392b;
+                font-size: 12px;
+                margin-top: 4px;
+                display: block;
+            }
 
-    <p:commandButton value="Cancelar" immediate="true"
-                     action="listarNinos?faces-redirect=true"
-                     styleClass="ui-button-secondary" />
-</h:form>
+            .button-bar {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 15px;
+                margin-top: 20px;
+            }
 
-</h:body>
+            .button-bar .ui-button {
+                min-width: 190px;
+                font-weight: bold;
+            }
+
+            .btn-primary {
+                background: linear-gradient(135deg, #9B59B6, #8e44ad);
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-primary:hover {
+                background: linear-gradient(135deg, #8e44ad, #732d91);
+            }
+
+            .btn-secondary {
+                background-color: #6c757d;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-secondary:hover {
+                background-color: #5a6268;
+            }
+
+            .btn-info {
+                background-color: #5dade2;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-info:hover {
+                background-color: #3498db;
+            }
+
+            .ui-messages {
+                margin-bottom: 20px;
+            }
+        </style>
+    </h:head>
+
+    <h:body>
+        <header>
+            <h:graphicImage library="img" name="logoSinFondo.png" alt="ICBF Conecta" />
+            <nav>
+                <ul>
+                    <li><h:link outcome="madreDashboard" value="Inicio"><i class="fas fa-home"></i></h:link></li>
+                    <li><h:link outcome="listarNinos" value=" Matrículas"><i class="fas fa-user-graduate"></i></h:link></li>
+                    <li><h:link outcome="planeaciones" value=" Planeaciones"><i class="fas fa-book"></i></h:link></li>
+                    <li><h:link outcome="desarrollo" value=" Desarrollo"><i class="fas fa-child"></i></h:link></li>
+                    <li><h:link outcome="correos" value=" Enviar Correos"><i class="fas fa-envelope"></i></h:link></li>
+                    <li>
+                        <h:form>
+                            <h:commandLink action="#{loginBean.logout}">
+                                <i class="fas fa-sign-out-alt"></i> Cerrar sesión
+                            </h:commandLink>
+                        </h:form>
+                    </li>
+                </ul>
+            </nav>
+        </header>
+
+        <div class="main-title">
+            ICBF CONECTA || Registro de acudiente
+        </div>
+
+        <div class="form-wrapper">
+            <h:form enctype="multipart/form-data">
+                <p:messages showDetail="true" showSummary="false" closable="true" />
+
+                <div class="form-card">
+                    <h3>Datos del usuario padre</h3>
+                    <h:panelGrid columns="2" columnClasses="label,value" styleClass="input-grid">
+                        <h:outputLabel for="nombresP" value="Nombres:" />
+                        <h:inputText id="nombresP" value="#{padreMatriculaBean.usuarioPadre.nombres}" required="true"
+                                     requiredMessage="Los nombres son obligatorios." styleClass="input-field" />
+
+                        <h:outputLabel for="apellidosP" value="Apellidos:" />
+                        <h:inputText id="apellidosP" value="#{padreMatriculaBean.usuarioPadre.apellidos}" required="true"
+                                     requiredMessage="Los apellidos son obligatorios." styleClass="input-field" />
+
+                        <h:outputLabel for="documentoP" value="Documento:" />
+                        <h:inputText id="documentoP" value="#{padreMatriculaBean.usuarioPadre.documento}" required="true"
+                                     maxlength="15"
+                                     requiredMessage="El documento es obligatorio."
+                                     validatorMessage="El documento solo debe contener números."
+                                     styleClass="input-field">
+                            <f:validateRegex pattern="\d+" />
+                        </h:inputText>
+                        <h:message for="documentoP" styleClass="error-msg" />
+
+                        <h:outputLabel for="correoP" value="Correo electrónico:" />
+                        <h:inputText id="correoP" value="#{padreMatriculaBean.usuarioPadre.correo}" required="true"
+                                     requiredMessage="El correo es obligatorio." styleClass="input-field" />
+
+                        <h:outputLabel for="direccionP" value="Dirección:" />
+                        <h:inputText id="direccionP" value="#{padreMatriculaBean.usuarioPadre.direccion}" styleClass="input-field" />
+
+                        <h:outputLabel for="telefonoP" value="Teléfono:" />
+                        <h:inputText id="telefonoP" value="#{padreMatriculaBean.usuarioPadre.telefono}" maxlength="15"
+                                     validatorMessage="El teléfono solo debe contener números."
+                                     styleClass="input-field">
+                            <f:validateRegex pattern="\d*" />
+                        </h:inputText>
+                        <h:message for="telefonoP" styleClass="error-msg" />
+
+                        <h:outputLabel for="pass1" value="Contraseña:" />
+                        <h:inputSecret id="pass1" value="#{padreMatriculaBean.password1}" required="true"
+                                       redisplay="true"
+                                       requiredMessage="La contraseña es obligatoria."
+                                       styleClass="input-field" />
+
+                        <h:outputLabel for="pass2" value="Confirmar contraseña:" />
+                        <h:inputSecret id="pass2" value="#{padreMatriculaBean.password2}" required="true"
+                                       redisplay="true"
+                                       requiredMessage="Debes confirmar la contraseña."
+                                       styleClass="input-field" />
+                    </h:panelGrid>
+                </div>
+
+                <div class="form-card">
+                    <h3>Información complementaria</h3>
+                    <h:panelGrid columns="2" columnClasses="label,value" styleClass="input-grid">
+                        <h:outputLabel for="ocupacion" value="Ocupación:" />
+                        <h:inputText id="ocupacion" value="#{padreMatriculaBean.padre.ocupacion}" styleClass="input-field" />
+
+                        <h:outputLabel for="estrato" value="Estrato:" />
+                        <h:inputText id="estrato" value="#{padreMatriculaBean.padre.estrato}" maxlength="2"
+                                     validatorMessage="El estrato debe ser numérico."
+                                     styleClass="input-field">
+                            <f:validateRegex pattern="\d*" />
+                        </h:inputText>
+                        <h:message for="estrato" styleClass="error-msg" />
+
+                        <h:outputLabel for="telEmerg" value="Teléfono emergencia:" />
+                        <h:inputText id="telEmerg" value="#{padreMatriculaBean.padre.telefonoContactoEmergencia}" maxlength="15"
+                                     validatorMessage="El teléfono de emergencia solo debe contener números."
+                                     styleClass="input-field">
+                            <f:validateRegex pattern="\d*" />
+                        </h:inputText>
+                        <h:message for="telEmerg" styleClass="error-msg" />
+
+                        <h:outputLabel for="nomEmerg" value="Nombre contacto emergencia:" />
+                        <h:inputText id="nomEmerg" value="#{padreMatriculaBean.padre.nombreContactoEmergencia}" styleClass="input-field" />
+
+                        <h:outputLabel for="sitEcon" value="Situación económica hogar:" />
+                        <h:inputTextarea id="sitEcon" value="#{padreMatriculaBean.padre.situacionEconomicaHogar}" rows="4"
+                                         styleClass="input-field" />
+
+                        <h:outputLabel for="docPadre" value="Documento de identidad (imagen):" />
+                        <h:inputFile id="docPadre" value="#{padreMatriculaBean.documentoPart}" required="true"
+                                     requiredMessage="Debes adjuntar el documento de identidad." />
+                    </h:panelGrid>
+                </div>
+
+                <div class="button-bar">
+                    <p:commandButton value="Guardar y continuar" icon="pi pi-save"
+                                     action="#{padreMatriculaBean.guardarPadre}"
+                                     ajax="false"
+                                     styleClass="btn-primary" />
+
+                    <p:commandButton value="Cancelar" icon="pi pi-times"
+                                     type="reset"
+                                     styleClass="btn-secondary" />
+
+                    <p:commandButton value="Volver al listado" icon="pi pi-arrow-left"
+                                     action="listarNinos?faces-redirect=true"
+                                     ajax="false"
+                                     immediate="true"
+                                     styleClass="btn-info" />
+                </div>
+            </h:form>
+        </div>
+    </h:body>
+</f:view>
 </html>

--- a/web/listarNinos.xhtml
+++ b/web/listarNinos.xhtml
@@ -1,103 +1,302 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+<f:view>
+    <f:metadata>
+        <f:viewAction action="#{sessionBean.verificarAcceso('madre_comunitaria')}" />
+    </f:metadata>
 
-<h:head>
-    <h:outputStylesheet name="primeicons/primeicons.css" library="primefaces" />
-    <title>Listado de Niños</title>
-</h:head>
-<h:body>
+    <h:head>
+        <title>Niños Matriculados</title>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+        <style>
+            * {
+                box-sizing: border-box;
+            }
 
-    <h:form id="formNinos">
-        <h2>Niños Matriculados en Mi Hogar</h2>
+            body {
+                margin: 0;
+                font-family: 'Roboto', sans-serif;
+                background-image: url("#{resource['img/fondito.png']}");
+                background-size: cover;
+                background-position: center;
+                background-repeat: no-repeat;
+                background-attachment: fixed;
+                color: #4a2d73;
+            }
 
-        <!-- Mensajes globales -->
-        <p:messages id="mensajes" showDetail="true" showSummary="true" closable="true" />
+            header {
+                background-color: rgba(255, 255, 255, 0.85);
+                padding: 15px 30px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                border-bottom: 2px solid #e5d5f5;
+                backdrop-filter: blur(4px);
+                flex-wrap: wrap;
+            }
 
-        <!-- Tabla con PrimeFaces -->
-        <p:dataTable id="tablaNinos"
-                     value="#{ninoBean.listaNinos}" var="n"
-                     paginator="true" rows="10"
-                     emptyMessage="No hay niños matriculados en este hogar"
-                     scrollable="true" scrollHeight="400">
+            header img {
+                height: 60px;
+            }
 
-            <!-- Columnas -->
-            <p:column headerText="ID" style="width:60px;">
-                <h:outputText value="#{n.idNino}" />
-            </p:column>
+            nav ul {
+                list-style: none;
+                display: flex;
+                gap: 20px;
+                padding: 0;
+                margin: 0;
+                flex-wrap: wrap;
+            }
 
-            <p:column headerText="Nombres">
-                <h:outputText value="#{n.nombres}" />
-            </p:column>
+            nav ul li a {
+                text-decoration: none;
+                color: #9B59B6;
+                font-weight: bold;
+                font-size: 16px;
+                padding: 8px 12px;
+                border-radius: 6px;
+                transition: background-color 0.3s ease;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
 
-            <p:column headerText="Apellidos">
-                <h:outputText value="#{n.apellidos}" />
-            </p:column>
+            nav ul li a:hover {
+                background-color: #f3c1e5;
+            }
 
-            <p:column headerText="Documento">
-                <h:outputText value="#{n.documento}" />
-            </p:column>
+            .main-title {
+                text-align: center;
+                margin-top: 20px;
+                padding: 20px;
+                font-size: 26px;
+                font-weight: bold;
+                color: #7a3eb1;
+                background-color: rgba(255, 255, 255, 0.75);
+                margin: 20px auto;
+                width: 80%;
+                border-radius: 12px;
+                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+            }
 
-            <p:column headerText="Fecha Nacimiento">
-                <h:outputText value="#{n.fechaNacimiento}">
-                    <f:convertDateTime pattern="dd/MM/yyyy" />
-                </h:outputText>
-            </p:column>
+            .card {
+                background-color: rgba(255, 255, 255, 0.93);
+                border-radius: 15px;
+                padding: 30px;
+                max-width: 1150px;
+                margin: 0 auto 40px;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+                border-left: 6px solid #9B59B6;
+            }
 
-            <p:column headerText="Género">
-                <h:outputText value="#{n.genero}" />
-            </p:column>
+            .card-title {
+                margin: 0 0 15px;
+                font-size: 22px;
+                color: #5e3370;
+                text-align: center;
+            }
 
-            <p:column headerText="Nacionalidad">
-                <h:outputText value="#{n.nacionalidad}" />
-            </p:column>
+            .actions-column .ui-button {
+                margin: 0 4px;
+            }
 
-            <!-- Mostrar foto directamente -->
-            <p:column headerText="Foto">
-                <h:graphicImage value="http://localhost:8080/icbfconecta-jsf/uploads/#{n.foto}"
-                                width="60" height="60" alt="Foto Niño"/>
-            </p:column>
+            .actions-column .ui-button .ui-button-text-only .ui-button-text {
+                padding: 0;
+            }
 
-            <!-- Acciones -->
-            <p:column headerText="Acciones" style="width:120px; text-align:center;">
-                <!-- Editar -->
-                <p:commandButton icon="pi pi-pencil" title="Editar"
-                                 action="editarNino.xhtml"
-                                 ajax="false">
-                    <f:param name="idNino" value="#{n.idNino}" />
-                </p:commandButton>
+            .foto-preview {
+                border-radius: 10px;
+                box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+                object-fit: cover;
+            }
 
-                <!-- Eliminar -->
-                <p:commandButton icon="pi pi-trash" title="Eliminar"
-                                 styleClass="ui-button-danger"
-                                 actionListener="#{ninoBean.eliminar(n.idNino)}"
-                                 update="formNinos:mensajes formNinos:tablaNinos"
-                                 process="@this"
-                                 onclick="return confirm('¿Seguro que deseas eliminar este niño?');"/>
-            </p:column>
+            .action-buttons {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 15px;
+                justify-content: center;
+                margin-top: 25px;
+            }
 
-        </p:dataTable>
+            .action-buttons .ui-button {
+                min-width: 200px;
+                font-weight: bold;
+            }
 
-        <br/>
+            .btn-primary {
+                background: linear-gradient(135deg, #9B59B6, #8e44ad);
+                color: #fff !important;
+                border: none;
+            }
 
-        <!-- Botones de navegación -->
-        <p:commandButton value="Registrar Nuevo Niño"
-                         action="crearPadre?faces-redirect=true"
-                         icon="pi pi-plus"
-                         ajax="false" />
+            .btn-primary:hover {
+                background: linear-gradient(135deg, #8e44ad, #732d91);
+            }
 
-        <p:commandButton value="Volver al Dashboard"
-                         action="madreDashboard?faces-redirect=true"
-                         icon="pi pi-home"
-                         ajax="false" />
+            .btn-secondary {
+                background-color: #6c757d;
+                color: #fff !important;
+                border: none;
+            }
 
-        <p:commandButton value="Ver Reporte de Niños"
-                         action="ReporteListado?faces-redirect=true"
-                         icon="pi pi-list"
-                         ajax="false" />
-    </h:form>
+            .btn-secondary:hover {
+                background-color: #5a6268;
+            }
 
-</h:body>
+            .btn-info {
+                background-color: #5dade2;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-info:hover {
+                background-color: #3498db;
+            }
+
+            .btn-danger {
+                background-color: #e74c3c;
+                color: #fff !important;
+                border: none;
+            }
+
+            .btn-danger:hover {
+                background-color: #c0392b;
+            }
+
+            .ui-datatable thead th {
+                background: #f3c1e5;
+                color: #5e3370;
+                text-align: center;
+            }
+
+            .ui-datatable tbody td {
+                text-align: center;
+                color: #4a2d73;
+            }
+
+            .ui-messages {
+                margin-bottom: 20px;
+            }
+        </style>
+    </h:head>
+
+    <h:body>
+        <header>
+            <h:graphicImage library="img" name="logoSinFondo.png" alt="ICBF Conecta" />
+            <nav>
+                <ul>
+                    <li><h:link outcome="madreDashboard" value="Inicio"><i class="fas fa-home"></i></h:link></li>
+                    <li><h:link outcome="listarNinos" value=" Matrículas"><i class="fas fa-user-graduate"></i></h:link></li>
+                    <li><h:link outcome="planeaciones" value=" Planeaciones"><i class="fas fa-book"></i></h:link></li>
+                    <li><h:link outcome="desarrollo" value=" Desarrollo"><i class="fas fa-child"></i></h:link></li>
+                    <li><h:link outcome="correos" value=" Enviar Correos"><i class="fas fa-envelope"></i></h:link></li>
+                    <li>
+                        <h:form>
+                            <h:commandLink action="#{loginBean.logout}">
+                                <i class="fas fa-sign-out-alt"></i> Cerrar sesión
+                            </h:commandLink>
+                        </h:form>
+                    </li>
+                </ul>
+            </nav>
+        </header>
+
+        <div class="main-title">
+            ICBF CONECTA || Matrículas de niños inscritos en tu hogar
+        </div>
+
+        <div class="card">
+            <h3 class="card-title">Listado de niños matriculados</h3>
+            <h:form id="formNinos">
+                <p:messages id="mensajes" showDetail="true" showSummary="false" closable="true" />
+
+                <p:dataTable id="tablaNinos"
+                             value="#{ninoBean.listaNinos}" var="n"
+                             paginator="true" rows="10"
+                             reflow="true"
+                             emptyMessage="No hay niños matriculados en este hogar"
+                             styleClass="tabla-ninos">
+
+                    <p:column headerText="ID" style="width:70px;">
+                        <h:outputText value="#{n.idNino}" />
+                    </p:column>
+
+                    <p:column headerText="Nombres">
+                        <h:outputText value="#{n.nombres}" />
+                    </p:column>
+
+                    <p:column headerText="Apellidos">
+                        <h:outputText value="#{n.apellidos}" />
+                    </p:column>
+
+                    <p:column headerText="Documento">
+                        <h:outputText value="#{n.documento}" />
+                    </p:column>
+
+                    <p:column headerText="Fecha Nacimiento">
+                        <h:outputText value="#{n.fechaNacimiento}">
+                            <f:convertDateTime pattern="dd/MM/yyyy" />
+                        </h:outputText>
+                    </p:column>
+
+                    <p:column headerText="Género">
+                        <h:outputText value="#{n.genero}" />
+                    </p:column>
+
+                    <p:column headerText="Nacionalidad">
+                        <h:outputText value="#{n.nacionalidad}" />
+                    </p:column>
+
+                    <p:column headerText="Foto" style="width:120px;">
+                        <h:panelGroup rendered="#{not empty n.foto}">
+                            <h:graphicImage value="#{facesContext.externalContext.requestContextPath}/uploads/#{n.foto}"
+                                            width="70" height="70" alt="Foto Niño" styleClass="foto-preview" />
+                        </h:panelGroup>
+                        <h:outputText value="Sin foto" rendered="#{empty n.foto}" />
+                    </p:column>
+
+                    <p:column headerText="Acciones" styleClass="actions-column" style="text-align:center; width:150px;">
+                        <p:commandButton icon="pi pi-pencil" title="Editar"
+                                         action="editarNino?faces-redirect=true"
+                                         ajax="false"
+                                         styleClass="btn-info">
+                            <f:param name="idNino" value="#{n.idNino}" />
+                        </p:commandButton>
+
+                        <p:commandButton icon="pi pi-trash" title="Eliminar"
+                                         styleClass="btn-danger"
+                                         actionListener="#{ninoBean.eliminar(n.idNino)}"
+                                         update="formNinos:mensajes formNinos:tablaNinos"
+                                         process="@this"
+                                         onclick="return confirm('¿Seguro que deseas eliminar este niño?');"/>
+                    </p:column>
+                </p:dataTable>
+
+                <div class="action-buttons">
+                    <p:commandButton value="Registrar nuevo niño"
+                                     icon="pi pi-user-plus"
+                                     action="crearPadre?faces-redirect=true"
+                                     ajax="false"
+                                     styleClass="btn-primary" />
+
+                    <p:commandButton value="Ver reportes"
+                                     icon="pi pi-list"
+                                     action="ReporteListado?faces-redirect=true"
+                                     ajax="false"
+                                     styleClass="btn-info" />
+
+                    <p:commandButton value="Volver al panel"
+                                     icon="pi pi-arrow-left"
+                                     action="madreDashboard?faces-redirect=true"
+                                     ajax="false"
+                                     styleClass="btn-secondary" />
+                </div>
+            </h:form>
+        </div>
+    </h:body>
+</f:view>
 </html>


### PR DESCRIPTION
## Summary
- filtrar la lista de niños y los hogares disponibles según la madre comunitaria que inicie sesión
- actualizar el estilo de las vistas de matrícula y reportes para alinear con el panel de madres y añadir botones de navegación
- agregar validaciones de solo números para documentos y teléfonos en los formularios de matrícula

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d2014b771483328f87062ab146ac0b