### PR TITLE
Fix hidden padre id conversion on niño registration

### DIFF
--- a/src/java/control/NinoBean.java
+++ b/src/java/control/NinoBean.java
@@ -279,6 +279,26 @@ public class NinoBean implements Serializable {
         this.padreIdSeleccionado = padreIdSeleccionado;
     }
 
+    public String getPadreIdSeleccionadoHidden() {
+        return padreIdSeleccionado != null ? padreIdSeleccionado.toString() : "";
+    }
+
+    public void setPadreIdSeleccionadoHidden(String valor) {
+        if (valor == null || valor.trim().isEmpty()) {
+            padreIdSeleccionado = null;
+            padreSeleccionado = null;
+            usuarioPadreSeleccionado = null;
+            return;
+        }
+        try {
+            padreIdSeleccionado = Integer.valueOf(valor.trim());
+        } catch (NumberFormatException e) {
+            padreIdSeleccionado = null;
+            padreSeleccionado = null;
+            usuarioPadreSeleccionado = null;
+        }
+    }
+
     public Padre getPadreSeleccionado() {
         return padreSeleccionado;
     }

--- a/web/crearNino.xhtml
+++ b/web/crearNino.xhtml
@@ -305,7 +305,7 @@
                     <h:link outcome="crearPadre" value="Registrar datos del padre" />
                 </h:panelGroup>
 
-                <h:inputHidden value="#{ninoBean.padreIdSeleccionado}" />
+                <h:inputHidden value="#{ninoBean.padreIdSeleccionadoHidden}" />
 
                 <div class="card">
                     <h3>Datos del niño</h3>


### PR DESCRIPTION
## Summary
- add string-backed accessors in `NinoBean` so the padre id stored in the view uses a safe textual representation
- bind the hidden padre id field in `crearNino.xhtml` to the new accessor to avoid JSF casting errors when the padre id is numeric

## Testing
- ⚠️ `ant -f build.xml compile` *(fails: ant command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d20e4d42508332954c266fe78f198f