### PR TITLE
Stabilize padre selection state for niño matriculation

### DIFF
--- a/web/crearNino.xhtml
+++ b/web/crearNino.xhtml
@@ -305,7 +305,9 @@
                     <h:link outcome="crearPadre" value="Registrar datos del padre" />
                 </h:panelGroup>
 
-                <h:inputHidden value="#{ninoBean.padreIdSeleccionado}" />
+                <h:inputHidden value="#{ninoBean.padreIdSeleccionadoHidden}">
+                    <f:converter converterId="javax.faces.Long" />
+                </h:inputHidden>
 
                 <div class="card">
                     <h3>Datos del niño</h3>


### PR DESCRIPTION
## Summary
- add DAO accessors and a sync helper in `NinoBean` so the padre selection and its user details are reloaded safely across postbacks
- treat the hidden padre id as a `Long`, keeping the child form bound to the padre even after saving and when DAOs are rehydrated lazily
- declare an explicit JSF converter for the hidden padre id field in `crearNino.xhtml` to avoid numeric casting issues during model updates

## Testing
- `javac -cp "lib/*:lib/javaee-endorsed-api-7.0/*" -d build/tmpclasses $(find src/java -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_b_68d20e4d42508332954c266fe78f198f